### PR TITLE
Account for the redesign of SerializableHandleGraph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ set(gbwt_LIB "${SOURCE_DIR}/lib")
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
-  GIT_TAG "5756a2cd1819917559b2a421d5bb99ff30c9b061"
+  GIT_TAG "962018b84d8525ca93e79efd5f3726a0683bcfdf"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")

--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -5,6 +5,8 @@
 #include <queue>
 #include <stack>
 
+#include <arpa/inet.h>
+
 #include <omp.h>
 
 namespace gbwtgraph
@@ -347,8 +349,16 @@ GBWTGraph::has_edge(const handle_t& left, const handle_t& right) const
 
 //------------------------------------------------------------------------------
 
+uint32_t
+GBWTGraph::get_magic_number() const {
+    // Specify what it should look like on the wire
+    const char* bytes = "GBG ";
+    // Convert to a host byte order number
+    return ntohl(*((const uint32_t*) bytes));
+}
+
 void
-GBWTGraph::serialize(std::ostream& out) const
+GBWTGraph::serialize_members(std::ostream& out) const
 {
   // Serialize the header.
   out.write(reinterpret_cast<const char*>(&(this->header)), sizeof(Header));
@@ -368,14 +378,14 @@ GBWTGraph::serialize(std::ostream& out) const
 }
 
 void
-GBWTGraph::deserialize(std::istream& in)
+GBWTGraph::deserialize_members(std::istream& in)
 {
   // Load the header.
   in.read(reinterpret_cast<char*>(&(this->header)), sizeof(Header));
   if(!(this->header.check()))
   {
-    std::cerr << "GBWTGraph::deserialize(): Invalid or old graph file" << std::endl;
-    std::cerr << "GBWTGraph::deserialize(): Graph version is " << this->header.version << "; expected " << Header::VERSION << std::endl;
+    std::cerr << "GBWTGraph::deserialize_members(): Invalid or old graph file" << std::endl;
+    std::cerr << "GBWTGraph::deserialize_members(): Graph version is " << this->header.version << "; expected " << Header::VERSION << std::endl;
     return;
   }
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -167,16 +167,24 @@ public:
 
 public:
 
-  // Serialize the sequences to the ostream.
-  virtual void serialize(std::ostream& out) const;
-
-  // Load the sequences from the istream.
-  // Call set_gbwt() before using the graph.
-  virtual void deserialize(std::istream& in);
-
   // Set the GBWT index used for graph topology.
   // Call deserialize() before using the graph.
+  // MUST be called before using the graph if the graph is deserialize()-ed.
   void set_gbwt(const gbwt::GBWT& gbwt_index);
+  
+  /// Return a magic number to identify serialized GBWTGraphs.
+  virtual uint32_t get_magic_number() const;
+  
+protected:
+    
+  /// Underlying implementation for "serialize" method.
+  /// Serialize the sequences to the ostream.
+  virtual void serialize_members(std::ostream& out) const;
+
+  /// Underlying implementation to "deserialize" method.
+  /// Load the sequences from the istream.
+  /// User must call set_gbwt() before using the graph.
+  virtual void deserialize_members(std::istream& in);
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -2,6 +2,7 @@
 #define GBWTGRAPH_UTILS_H
 
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/serializable_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 
 #include <iostream>


### PR DESCRIPTION
We need this in order for https://github.com/vgteam/vg/pull/2602 to be testable, so we can upgrade to the latest libhandlegraph where SerializableHandleGraph moved headers.