### PR TITLE
Track regions when computing minimizers

### DIFF
--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -798,6 +798,9 @@ public:
           std::get<0>(result[finished_through]).offset < (start_pos - 1))
         {
           // Compute region length based on it stopping here
+          std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
+            << " finished due to out of range offset " << std::get<0>(result[finished_through]).offset
+            << " < start pos " << (start_pos - 1) << std::endl;
           std::get<2>(result[finished_through]) = end_pos - std::get<1>(result[finished_through]);
           finished_through++;
         }
@@ -826,6 +829,9 @@ public:
                 // There can only ever really be one minimizer at a given start
                 // position. So look for the next one 1 base to the right.
                 next_read_offset = buffer.at(i).offset + 1;
+                
+                std::cerr << "Minimizer " << std::get<0>(result.back()).key.decode(this->k())
+                  << " added" << std::endl;
               }
             }
             
@@ -835,6 +841,8 @@ public:
               std::get<0>(result.back()).hash != std::get<0>(result[finished_through]).hash)
             {
               // The window before the one we are looking at was the last one for this minimizer.
+              std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
+                << " finished due to replacement" << std::endl;
               std::get<2>(result[finished_through]) = end_pos - std::get<1>(result[finished_through]);
               finished_through++;
             }
@@ -852,6 +860,8 @@ public:
     {
       // The region length is from the region start to the string end
       std::get<2>(result[finished_through]) = total_length - std::get<1>(result[finished_through]);
+      std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
+        << " finished due to end of string" << std::endl;
       finished_through++;
     }
 

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -124,6 +124,9 @@ public:
     }
   }
 
+  /// Encode a string of size k to a key.
+  static Key64 encode(const std::string& sequence);
+
   /// Decode the key back to a string, given the kmer size used.
   std::string decode(size_t k) const;
 
@@ -231,6 +234,9 @@ public:
       }
     }
   }
+
+  /// Encode a string of size k to a key.
+  static Key128 encode(const std::string& sequence);
 
   /// Decode the key back to a string, given the kmer size used.
   std::string decode(size_t k) const;

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -798,19 +798,12 @@ public:
         // Work out the past-the-end index of the window we have just finished (not the current window)
         size_t prev_past_end_pos = window_start + window_length - 1;
       
-        std::cerr << "At window start " << window_start << " (current kmer start " << (start_pos - 1)
-          << ", prev past-end " << prev_past_end_pos << ")" << std::endl;
-      
         // Finish off end positions for results that weren't replaced but are going out of range
         while(finished_through < result.size() &&
           std::get<0>(result[finished_through]).offset < window_start)
         {
           // Compute region length based on it stopping at the previous step
           std::get<2>(result[finished_through]) = prev_past_end_pos - std::get<1>(result[finished_through]);
-          std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-            << " finished after covering " << std::get<2>(result[finished_through])
-            << " bases due to out of range offset " << std::get<0>(result[finished_through]).offset
-            << " < window start " << window_start << std::endl;
           finished_through++;
         }
       
@@ -837,9 +830,6 @@ public:
                 // There can only ever really be one minimizer at a given start
                 // position. So look for the next one 1 base to the right.
                 next_read_offset = buffer.at(i).offset + 1;
-                
-                std::cerr << "Minimizer " << std::get<0>(result.back()).key.decode(this->k())
-                  << " added at offset " <<  std::get<0>(result.back()).offset << std::endl;
               }
             }
             
@@ -850,8 +840,6 @@ public:
             {
               // The window before the one we are looking at was the last one for this minimizer.
               std::get<2>(result[finished_through]) = prev_past_end_pos - std::get<1>(result[finished_through]);
-              std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-                << " finished due to replacement after covering " << std::get<2>(result[finished_through]) << " bases" << std::endl;
               finished_through++;
             }
           }
@@ -864,9 +852,6 @@ public:
     {
       // The region length is from the region start to the string end
       std::get<2>(result[finished_through]) = total_length - std::get<1>(result[finished_through]);
-      std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-        << " finished after covering " << std::get<2>(result[finished_through])
-        << " bases due to end of string" << std::endl;
       finished_through++;
     }
 

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -602,7 +602,8 @@ public:
   /*
     Returns all minimizers in the string specified by the iterators. The return
     value is a vector of minimizers sorted by their offsets. If there are multiple
-    occurrences of a minimizer in a window, return all of them.
+    occurrences of one or more minimizer keys with the same hash in a window,
+    return all of them.
   */
   std::vector<minimizer_type> minimizers(std::string::const_iterator begin, std::string::const_iterator end) const
   {
@@ -631,10 +632,10 @@ public:
         // 1) this is the first minimizer we encounter;
         // 2) the last reported minimizer had the same key (we may have new occurrences); or
         // 3) the first candidate is located after the last reported minimizer.
-        if(result.empty() || result.back().key == buffer.front().key || result.back().offset < buffer.front().offset)
+        if(result.empty() || result.back().hash == buffer.front().hash || result.back().offset < buffer.front().offset)
         {
           // Insert all new occurrences of the minimizer in the window.
-          for(size_t i = buffer.begin(); i < buffer.end() && buffer.at(i).key == buffer.front().key; i++)
+          for(size_t i = buffer.begin(); i < buffer.end() && buffer.at(i).hash == buffer.front().hash; i++)
           {
             if(buffer.at(i).offset >= next_read_offset)
             {
@@ -670,9 +671,9 @@ public:
     Returns all minimizers in the string specified by the iterators, together
     with the weight of how many windows they arise from. The return value is a
     vector of pairs of minimizers and window counts sorted by their offsets. If
-    there are multiple occurrences of a minimizer in a window, they are all
-    returned, but the window's weight is all assigned to an arbitrary
-    minimizer that it contains.
+    there are multiple occurrences of one or more minimizer keys with the same
+    hash in a window, they are all returned, but the window's weight is all
+    assigned to an arbitrary minimizer that it contains.
   */
   std::vector<std::pair<minimizer_type, size_t>> weighted_minimizers(std::string::const_iterator begin, std::string::const_iterator end) const
   {
@@ -696,19 +697,19 @@ public:
       if(valid_chars >= this->k()) { buffer.advance(start_pos, forward_key, reverse_key); }
       else                         { buffer.advance(start_pos); }
       ++iter;
-      // If we have at least k valid characters, we can advance the starting position of the next kmer.
+      // If we have passed at least k characters, we must advance the starting position of the next kmer.
       if(static_cast<size_t>(iter - begin) >= this->k()) { start_pos++; }
       // We have a full window with a minimizer.
       if(static_cast<size_t>(iter - begin) >= window_length && !buffer.empty())
       {
         // Insert the candidates if:
         // 1) this is the first minimizer we encounter;
-        // 2) the last reported minimizer had the same key (we may have new occurrences); or
+        // 2) the last reported minimizer had the same hash (we may have new occurrences); or
         // 3) the first candidate is located after the last reported minimizer.
-        if(result.empty() || result.back().first.key == buffer.front().key || result.back().first.offset < buffer.front().offset)
+        if(result.empty() || result.back().first.hash == buffer.front().hash || result.back().first.offset < buffer.front().offset)
         {
           // Insert all new occurrences of the minimizer in the window.
-          for(size_t i = buffer.begin(); i < buffer.end() && buffer.at(i).key == buffer.front().key; i++)
+          for(size_t i = buffer.begin(); i < buffer.end() && buffer.at(i).hash == buffer.front().hash; i++)
           {
             if(buffer.at(i).offset >= next_read_offset)
             {

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -792,9 +792,6 @@ public:
           std::get<0>(result[finished_through]).offset < (start_pos - 1))
         {
           // Compute region length based on it stopping here
-          std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-            << " finished due to out of range offset " << std::get<0>(result[finished_through]).offset
-            << " < start pos " << (start_pos - 1) << std::endl;
           std::get<2>(result[finished_through]) = end_pos - std::get<1>(result[finished_through]);
           finished_through++;
         }
@@ -823,9 +820,6 @@ public:
                 // There can only ever really be one minimizer at a given start
                 // position. So look for the next one 1 base to the right.
                 next_read_offset = buffer.at(i).offset + 1;
-                
-                std::cerr << "Minimizer " << std::get<0>(result.back()).key.decode(this->k())
-                  << " added" << std::endl;
               }
             }
             
@@ -835,8 +829,6 @@ public:
               std::get<0>(result.back()).hash != std::get<0>(result[finished_through]).hash)
             {
               // The window before the one we are looking at was the last one for this minimizer.
-              std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-                << " finished due to replacement" << std::endl;
               std::get<2>(result[finished_through]) = end_pos - std::get<1>(result[finished_through]);
               finished_through++;
             }
@@ -854,8 +846,6 @@ public:
     {
       // The region length is from the region start to the string end
       std::get<2>(result[finished_through]) = total_length - std::get<1>(result[finished_through]);
-      std::cerr << "Minimizer " << std::get<0>(result[finished_through]).key.decode(this->k())
-        << " finished due to end of string" << std::endl;
       finished_through++;
     }
 

--- a/minimizer.cpp
+++ b/minimizer.cpp
@@ -368,6 +368,22 @@ MinimizerHeader::operator==(const MinimizerHeader& another) const
 
 //------------------------------------------------------------------------------
 
+Key64
+Key64::encode(const std::string& sequence)
+{
+  key_type packed = 0;
+  for(auto c : sequence)
+  {
+    auto packed_char = CHAR_TO_PACK[c];
+    if(packed_char > PACK_MASK)
+    {
+      throw std::runtime_error("Key64::encode(): Cannot encode character '" + std::to_string(c) + "'");
+    }
+    packed = (packed << PACK_WIDTH) | packed_char;
+  }
+  return Key64(packed);
+}
+
 std::string
 Key64::decode(size_t k) const
 {
@@ -384,6 +400,31 @@ operator<<(std::ostream& out, Key64 value)
 {
   out << value.key;
   return out;
+}
+
+Key128
+Key128::encode(const std::string& sequence)
+{
+  size_t low_limit = (sequence.size() > FIELD_CHARS ? FIELD_CHARS : sequence.size());
+  
+  key_type packed_high = 0;
+  key_type packed_low = 0;
+  
+  for(size_t i = 0; i < sequence.size(); i++)
+  {
+    auto c = sequence[i];
+    auto packed_char = CHAR_TO_PACK[c];
+    if(packed_char > PACK_MASK)
+    {
+      throw std::runtime_error("Key128::encode(): Cannot encode character '" + std::to_string(c) + "'");
+    }
+    
+    key_type& pack_to = (i < sequence.size() - low_limit) ? packed_high : packed_low;
+    
+    pack_to = (pack_to << PACK_WIDTH) | packed_char;
+  }
+  
+  return Key128(packed_high, packed_low);
 }
 
 std::string

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -88,6 +88,13 @@ get_minimizer(KeyType key, typename gbwtgraph::MinimizerIndex<KeyType>::offset_t
   return { key, key.hash(), offset, orientation };
 }
 
+template<class KeyType>
+typename gbwtgraph::MinimizerIndex<KeyType>::minimizer_type
+get_minimizer(std::string key, typename gbwtgraph::MinimizerIndex<KeyType>::offset_type offset = 0, bool orientation = false)
+{
+  return get_minimizer(KeyType::encode(key), offset, orientation);
+}
+
 //------------------------------------------------------------------------------
 
 } // anonymous namespace

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <sstream>
 #include <vector>
+#include <iostream>
 
 #include <gbwtgraph/minimizer.h>
 
@@ -277,6 +278,33 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     //          *--*
     // Each window length will be at least k + w - 1 = 4 bases.
     
+    /*
+    Minimizer TCG added
+    Minimizer TCG finished due to out of range offset 0 < start pos 1
+    Minimizer ATT added
+    Minimizer ATT finished due to out of range offset 2 < start pos 3
+    Minimizer ATA added
+    Minimizer ATA finished due to out of range offset 3 < start pos 4
+    Minimizer TGT added
+    Minimizer TTG added
+    Minimizer TGT finished due to replacement
+    Minimizer ATT added
+    Minimizer TTG finished due to replacement
+    Minimizer ATT finished due to out of range offset 7 < start pos 8
+    Minimizer ATA added
+    Minimizer ATA finished due to out of range offset 8 < start pos 9
+    Minimizer AGT added
+    Minimizer AGT finished due to end of string
+    Minimizer of TCG strand 1 in range 0 length 4
+    Minimizer of ATA strand 0 in range 3 length 4
+    Minimizer of ATT strand 1 in range 1 length 5
+    Minimizer of TGT strand 1 in range 4 length 4
+    Minimizer of TTG strand 1 in range 5 length 4
+    Minimizer of ATA strand 0 in range 8 length 4
+    Minimizer of ATT strand 1 in range 6 length 5
+    Minimizer of AGT strand 1 in range 9 length 4
+    */    
+    
     correct =
     {
       std::make_tuple(get_minimizer<TypeParam>("TCG", 2, true), 0, 4),
@@ -308,7 +336,32 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     //         *--*
     //           ACT+
     //          *--*
+    
     // Note that no minimizers actually get replaced in this example; they all take their second possible window.
+
+    /*
+    Minimizer TCG added
+    Minimizer TCG finished due to out of range offset 0 < start pos 1
+    Minimizer AAT added
+    Minimizer AAT finished due to out of range offset 2 < start pos 3
+    Minimizer TAT added
+    Minimizer TAT finished due to out of range offset 3 < start pos 4
+    Minimizer TGT added
+    Minimizer TGT finished due to out of range offset 5 < start pos 6
+    Minimizer AAT added
+    Minimizer AAT finished due to out of range offset 7 < start pos 8
+    Minimizer TAT added
+    Minimizer TAT finished due to out of range offset 8 < start pos 9
+    Minimizer ACT added
+    Minimizer ACT finished due to end of string
+    Minimizer of TCG strand 1 in range 0 length 4
+    Minimizer of AAT strand 0 in range 1 length 5
+    Minimizer of TAT strand 1 in range 3 length 4
+    Minimizer of TGT strand 1 in range 4 length 5
+    Minimizer of AAT strand 0 in range 6 length 5
+    Minimizer of TAT strand 1 in range 8 length 4
+    Minimizer of ACT strand 0 in range 9 length 4
+    */
 
     correct =
     {
@@ -322,6 +375,11 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     };
   }
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(this->str.begin(), this->str.end());
+  for (size_t i = 0; i < result.size(); i++) {
+    std::cerr << "Minimizer of " << std::get<0>(result[i]).key.decode(index.k())
+        << " strand " << std::get<0>(result[i]).is_reverse
+        << " in range " << std::get<1>(result[i]) << " length " << std::get<2>(result[i]) << std::endl;
+  }
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -5,7 +5,6 @@
 #include <set>
 #include <sstream>
 #include <vector>
-#include <iostream>
 
 #include <gbwtgraph/minimizer.h>
 
@@ -360,11 +359,6 @@ TEST(MinimizerExtraction, HardMinimizersWithRegion)
     std::make_tuple(get_minimizer<TypeParam>("ACAAATGAACAATTGAGGGAAAGAGCAGC", 45, true), 13, 43) // #3
   };
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(seq.begin(), seq.end());
-  for (size_t i = 0; i < result.size(); i++) {
-    std::cerr << "Minimizer of " << std::get<0>(result[i]).key.decode(index.k())
-        << " strand " << std::get<0>(result[i]).is_reverse
-        << " in range " << std::get<1>(result[i]) << " length " << std::get<2>(result[i]) << std::endl;
-  }
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -277,34 +277,7 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     //           ACT-
     //          *--*
     // Each window length will be at least k + w - 1 = 4 bases.
-    
-    /*
-    Minimizer TCG added
-    Minimizer TCG finished due to out of range offset 0 < start pos 1
-    Minimizer ATT added
-    Minimizer ATT finished due to out of range offset 2 < start pos 3
-    Minimizer ATA added
-    Minimizer ATA finished due to out of range offset 3 < start pos 4
-    Minimizer TGT added
-    Minimizer TTG added
-    Minimizer TGT finished due to replacement
-    Minimizer ATT added
-    Minimizer TTG finished due to replacement
-    Minimizer ATT finished due to out of range offset 7 < start pos 8
-    Minimizer ATA added
-    Minimizer ATA finished due to out of range offset 8 < start pos 9
-    Minimizer AGT added
-    Minimizer AGT finished due to end of string
-    Minimizer of TCG strand 1 in range 0 length 4
-    Minimizer of ATA strand 0 in range 3 length 4
-    Minimizer of ATT strand 1 in range 1 length 5
-    Minimizer of TGT strand 1 in range 4 length 4
-    Minimizer of TTG strand 1 in range 5 length 4
-    Minimizer of ATA strand 0 in range 8 length 4
-    Minimizer of ATT strand 1 in range 6 length 5
-    Minimizer of AGT strand 1 in range 9 length 4
-    */    
-    
+   
     correct =
     {
       std::make_tuple(get_minimizer<TypeParam>("TCG", 2, true), 0, 4),
@@ -339,30 +312,6 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     
     // Note that no minimizers actually get replaced in this example; they all take their second possible window.
 
-    /*
-    Minimizer TCG added
-    Minimizer TCG finished due to out of range offset 0 < start pos 1
-    Minimizer AAT added
-    Minimizer AAT finished due to out of range offset 2 < start pos 3
-    Minimizer TAT added
-    Minimizer TAT finished due to out of range offset 3 < start pos 4
-    Minimizer TGT added
-    Minimizer TGT finished due to out of range offset 5 < start pos 6
-    Minimizer AAT added
-    Minimizer AAT finished due to out of range offset 7 < start pos 8
-    Minimizer TAT added
-    Minimizer TAT finished due to out of range offset 8 < start pos 9
-    Minimizer ACT added
-    Minimizer ACT finished due to end of string
-    Minimizer of TCG strand 1 in range 0 length 4
-    Minimizer of AAT strand 0 in range 1 length 5
-    Minimizer of TAT strand 1 in range 3 length 4
-    Minimizer of TGT strand 1 in range 4 length 5
-    Minimizer of AAT strand 0 in range 6 length 5
-    Minimizer of TAT strand 1 in range 8 length 4
-    Minimizer of ACT strand 0 in range 9 length 4
-    */
-
     correct =
     {
       std::make_tuple(get_minimizer<TypeParam>("TCG", 2, true), 0, 4),
@@ -375,11 +324,6 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     };
   }
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(this->str.begin(), this->str.end());
-  for (size_t i = 0; i < result.size(); i++) {
-    std::cerr << "Minimizer of " << std::get<0>(result[i]).key.decode(index.k())
-        << " strand " << std::get<0>(result[i]).is_reverse
-        << " in range " << std::get<1>(result[i]) << " length " << std::get<2>(result[i]) << std::endl;
-  }
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 
@@ -392,15 +336,35 @@ TEST(MinimizerExtraction, HardMinimizersWithRegion)
   MinimizerIndex<TypeParam> index(29, 11);
   std::string seq("ACCAGTTTTTTACACAAGCTGCTCTTTCCCTCAATTGTTCATTTGTCTCCTTGTCCAGGT");
   
+  // No replacements happen
+  
+  // 000000000011111111112222222222333333333344444444445555555555
+  // 012345678901234567890123456789012345678901234567890123456789
+  // ACCAGTTTTTTACACAAGCTGCTCTTTCCCTCAATTGTTCATTTGTCTCCTTGTCCAGGT
+  //       TTTTTACACAAGCTGCTCTTTCCCTCAAT-                        (#1)
+  // *-------------------------------------------*                
+  //             CACAAGCTGCTCTTTCCCTCAATTGTTCA+                  (#2)
+  //        *------------------------------------------*         
+  //                  GCTGCTCTTTCCCTCAATTGTTCATTTGT-             (#3)
+  //              *-----------------------------------------*    
+  //                         TTTCCCTCAATTGTTCATTTGTCTCCTTG+      (#4)
+  //                   *----------------------------------------*
+  // These then get sorted by minimizer offset, at the end for reverse strand minimizers.
+  
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> correct;
   correct =
   {
-    std::make_tuple(get_minimizer<TypeParam>("ACAAATGAACAATTGAGGGAAAGAGCAGC", 17 + 29 - 1, true), 17, 29 + 27),
-    std::make_tuple(get_minimizer<TypeParam>("CACAAGCTGCTCTTTCCCTCAATTGTTCA", 12, false), 12, 29 + 11 + 20),
-    std::make_tuple(get_minimizer<TypeParam>("TTTCCCTCAATTGTTCATTTGTCTCCTTG", 24, true), 24, 29 + 11 + 7),
-    std::make_tuple(get_minimizer<TypeParam>("ATTGAGGGAAAGAGCAGCTTGTGTAAAAA", 6 + 29 - 1, true), 0, 29 + 11 + 6)
+    std::make_tuple(get_minimizer<TypeParam>("CACAAGCTGCTCTTTCCCTCAATTGTTCA", 12, false), 7, 44), // #2
+    std::make_tuple(get_minimizer<TypeParam>("TTTCCCTCAATTGTTCATTTGTCTCCTTG", 24, false), 18, 42), // #4
+    std::make_tuple(get_minimizer<TypeParam>("ATTGAGGGAAAGAGCAGCTTGTGTAAAAA", 34, true), 0, 45), // #1
+    std::make_tuple(get_minimizer<TypeParam>("ACAAATGAACAATTGAGGGAAAGAGCAGC", 45, true), 13, 43) // #3
   };
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(seq.begin(), seq.end());
+  for (size_t i = 0; i < result.size(); i++) {
+    std::cerr << "Minimizer of " << std::get<0>(result[i]).key.decode(index.k())
+        << " strand " << std::get<0>(result[i]).is_reverse
+        << " in range " << std::get<1>(result[i]) << " length " << std::get<2>(result[i]) << std::endl;
+  }
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -5,7 +5,6 @@
 #include <set>
 #include <sstream>
 #include <vector>
-#include <iostream>
 
 #include <gbwtgraph/minimizer.h>
 
@@ -237,33 +236,6 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     //          *--*
     // Each window length will be at least k + w - 1 = 4 bases.
     
-    /*
-    Minimizer TCG added
-    Minimizer TCG finished due to out of range offset 0 < start pos 1
-    Minimizer ATT added
-    Minimizer ATT finished due to out of range offset 2 < start pos 3
-    Minimizer ATA added
-    Minimizer ATA finished due to out of range offset 3 < start pos 4
-    Minimizer TGT added
-    Minimizer TTG added
-    Minimizer TGT finished due to replacement
-    Minimizer ATT added
-    Minimizer TTG finished due to replacement
-    Minimizer ATT finished due to out of range offset 7 < start pos 8
-    Minimizer ATA added
-    Minimizer ATA finished due to out of range offset 8 < start pos 9
-    Minimizer AGT added
-    Minimizer AGT finished due to end of string
-    Minimizer of TCG strand 1 in range 0 length 4
-    Minimizer of ATA strand 0 in range 3 length 4
-    Minimizer of ATT strand 1 in range 1 length 5
-    Minimizer of TGT strand 1 in range 4 length 4
-    Minimizer of TTG strand 1 in range 5 length 4
-    Minimizer of ATA strand 0 in range 8 length 4
-    Minimizer of ATT strand 1 in range 6 length 5
-    Minimizer of AGT strand 1 in range 9 length 4
-    */    
-    
     correct =
     {
       std::make_tuple(get_minimizer<TypeParam>(3 * 16 + 1 * 4 + 2 * 1, 2, true), 0, 4),     // TCG
@@ -295,32 +267,7 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     //         *--*
     //           ACT+
     //          *--*
-    
     // Note that no minimizers actually get replaced in this example; they all take their second possible window.
-
-    /*
-    Minimizer TCG added
-    Minimizer TCG finished due to out of range offset 0 < start pos 1
-    Minimizer AAT added
-    Minimizer AAT finished due to out of range offset 2 < start pos 3
-    Minimizer TAT added
-    Minimizer TAT finished due to out of range offset 3 < start pos 4
-    Minimizer TGT added
-    Minimizer TGT finished due to out of range offset 5 < start pos 6
-    Minimizer AAT added
-    Minimizer AAT finished due to out of range offset 7 < start pos 8
-    Minimizer TAT added
-    Minimizer TAT finished due to out of range offset 8 < start pos 9
-    Minimizer ACT added
-    Minimizer ACT finished due to end of string
-    Minimizer of TCG strand 1 in range 0 length 4
-    Minimizer of AAT strand 0 in range 1 length 5
-    Minimizer of TAT strand 1 in range 3 length 4
-    Minimizer of TGT strand 1 in range 4 length 5
-    Minimizer of AAT strand 0 in range 6 length 5
-    Minimizer of TAT strand 1 in range 8 length 4
-    Minimizer of ACT strand 0 in range 9 length 4
-    */
 
     correct =
     {
@@ -334,11 +281,6 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
     };
   }
   std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(this->str.begin(), this->str.end());
-  for (size_t i = 0; i < result.size(); i++) {
-    std::cerr << "Minimizer of " << std::get<0>(result[i]).key.decode(index.k())
-        << " strand " << std::get<0>(result[i]).is_reverse
-        << " in range " << std::get<1>(result[i]) << " length " << std::get<2>(result[i]) << std::endl;
-  }
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -325,6 +325,27 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
   EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
 }
 
+TEST(MinimizerExtraction, HardMinimizersWithRegion)
+{
+
+  using TypeParam = Key128;
+
+  // Here's a case I caught not working correctly.
+  MinimizerIndex<TypeParam> index(29, 11);
+  std::string seq("ACCAGTTTTTTACACAAGCTGCTCTTTCCCTCAATTGTTCATTTGTCTCCTTGTCCAGGT");
+  
+  std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> correct;
+  correct =
+  {
+    std::make_tuple(get_minimizer<TypeParam>("ACAAATGAACAATTGAGGGAAAGAGCAGC", 17 + 29 - 1, true), 17, 29 + 27),
+    std::make_tuple(get_minimizer<TypeParam>("CACAAGCTGCTCTTTCCCTCAATTGTTCA", 12, false), 12, 29 + 11 + 20),
+    std::make_tuple(get_minimizer<TypeParam>("TTTCCCTCAATTGTTCATTTGTCTCCTTG", 24, true), 24, 29 + 11 + 7),
+    std::make_tuple(get_minimizer<TypeParam>("ATTGAGGGAAAGAGCAGCTTGTGTAAAAA", 6 + 29 - 1, true), 0, 29 + 11 + 6)
+  };
+  std::vector<std::tuple<typename MinimizerIndex<TypeParam>::minimizer_type, size_t, size_t>> result = index.minimizer_regions(seq.begin(), seq.end());
+  EXPECT_EQ(result, correct) << "Did not find the correct minimizers";
+}
+
 TYPED_TEST(MinimizerExtraction, WindowLength)
 {
   MinimizerIndex<TypeParam> index(3, 3);


### PR DESCRIPTION
OK, I think I have this actually working, and I have tests at different minimizer lengths.

This will let you keep track of the regions covered by the windows for which each minimizer is the minimizer, when computing minimizers.

I also wrote a utility function to pack kmers, to make the tests simpler.

It also includes a fix for the hash vs key comparison issue when determining the minimizers, although @jltsiren may have that fixed already?