### PR TITLE
Node to segment translation

### DIFF
--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -395,24 +395,21 @@ GBWTGraph::get_segment_name_and_offset(const handle_t& handle) const
     return std::pair<std::string, size_t>(std::to_string(id), 0);
   }
 
-  // Determine the range of node ids that precede `id` in the given orientation.
-  nid_t start = 0, limit = 0;
+  // Determine the total length of nodes in this segment that precede `id`
+  // in the given orientation.
+  size_t start = 0, limit = 0;
   if(this->get_is_reverse(handle))
   {
     auto successor = iter; ++successor;
-    start = id + 1; limit = successor->second;
+    start = this->node_offset(gbwt::Node::encode(id + 1, false));
+    limit = this->node_offset(gbwt::Node::encode(successor->second, false));
   }
   else
   {
-    start = iter->first; limit = id;
+    start = this->node_offset(gbwt::Node::encode(iter->second, false));
+    limit = this->node_offset(gbwt::Node::encode(id, false));
   }
-
-  // Determine the offset.
-  size_t offset = 0;
-  for(nid_t i = start; i < limit; i++)
-  {
-    offset += this->get_length(this->get_handle(i, false));
-  }
+  size_t offset = this->sequences.length(start, limit) / 2;
 
   return std::pair<std::string, size_t>(this->segments.str(iter->first), offset);
 }
@@ -435,24 +432,22 @@ GBWTGraph::get_segment_offset(const handle_t& handle) const
   auto iter = this->node_to_segment.predecessor(id);
   if(iter == this->node_to_segment.one_end()) { return 0; }
 
-  // Determine the range of node ids that precede `id` in the given orientation.
-  nid_t start = 0, limit = 0;
+  // Determine the total length of nodes in this segment that precede `id`
+  // in the given orientation.
+  size_t start = 0, limit = 0;
   if(this->get_is_reverse(handle))
   {
     auto successor = iter; ++successor;
-    start = id + 1; limit = successor->second;
+    start = this->node_offset(gbwt::Node::encode(id + 1, false));
+    limit = this->node_offset(gbwt::Node::encode(successor->second, false));
   }
   else
   {
-    start = iter->first; limit = id;
+    start = this->node_offset(gbwt::Node::encode(iter->second, false));
+    limit = this->node_offset(gbwt::Node::encode(id, false));
   }
+  size_t offset = this->sequences.length(start, limit) / 2;
 
-  // Determine the offset.
-  size_t offset = 0;
-  for(nid_t i = start; i < limit; i++)
-  {
-    offset += this->get_length(this->get_handle(i, false));
-  }
   return offset;
 }
 

--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -145,7 +145,7 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_s
   {
     gbwt::node_type node = offset + this->index->firstNode();
     nid_t id = gbwt::Node::id(node);
-    if(this->has_node(id)) { return std::string(); }
+    if(!(this->has_node(id))) { return std::string(); }
     handle_t handle = sequence_source.get_handle(id, gbwt::Node::is_reverse(node));
     return sequence_source.get_sequence(handle);
   });

--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -168,16 +168,14 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const SequenceSource& sequenc
     gbwt::node_type node = offset + this->index->firstNode();
     nid_t id = gbwt::Node::id(node);
     if(!(this->has_node(id))) { return 0; }
-    handle_t handle = sequence_source.get_handle(id, false);
-    return sequence_source.get_length(handle);
+    return sequence_source.get_length(id);
   },
   [&](size_t offset) -> std::string
   {
     gbwt::node_type node = offset + this->index->firstNode();
     nid_t id = gbwt::Node::id(node);
     if(!(this->has_node(id))) { return std::string(); }
-    handle_t handle = sequence_source.get_handle(id, false);
-    std::string result = sequence_source.get_sequence(handle);
+    std::string result = sequence_source.get_sequence(id);
     if(gbwt::Node::is_reverse(node)) { reverse_complement_in_place(result); }
     return result;
   });

--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <queue>
 #include <stack>
+#include <string>
 
 #include <arpa/inet.h>
 
@@ -20,6 +21,7 @@ constexpr size_t GBWTGraph::CHUNK_SIZE;
 
 constexpr std::uint32_t GBWTGraph::Header::TAG;
 constexpr std::uint32_t GBWTGraph::Header::VERSION;
+constexpr std::uint32_t GBWTGraph::Header::OLD_VERSION;
 
 //------------------------------------------------------------------------------
 
@@ -39,7 +41,7 @@ GBWTGraph::Header::Header() :
 bool
 GBWTGraph::Header::check() const
 {
-  return (this->tag == TAG && this->version == VERSION && this->flags == 0);
+  return (this->tag == TAG && (this->version == VERSION || this->version == OLD_VERSION) && this->flags == 0);
 }
 
 bool
@@ -80,6 +82,8 @@ GBWTGraph::swap(GBWTGraph& another)
   std::swap(this->header, another.header);
   this->sequences.swap(another.sequences);
   this->real_nodes.swap(another.real_nodes);
+  this->segments.swap(another.segments);
+  this->node_to_segment.swap(another.node_to_segment);
 }
 
 GBWTGraph&
@@ -98,6 +102,8 @@ GBWTGraph::operator=(GBWTGraph&& source)
     this->header = std::move(source.header);
     this->sequences = std::move(source.sequences);
     this->real_nodes = std::move(source.real_nodes);
+    this->segments = std::move(source.segments);
+    this->node_to_segment = std::move(source.node_to_segment);
   }
   return *this;
 }
@@ -109,6 +115,8 @@ GBWTGraph::copy(const GBWTGraph& source)
   this->header = source.header;
   this->sequences = source.sequences;
   this->real_nodes = source.real_nodes;
+  this->segments = source.segments;
+  this->node_to_segment = source.node_to_segment;
 }
 
 //------------------------------------------------------------------------------
@@ -123,22 +131,22 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_s
   // Build real_nodes to support has_node().
   this->determine_real_nodes();
 
-  // Determine the number of nodes and the total length of the sequences.
-  size_t potential_nodes = this->index->sigma() - this->index->firstNode();
-  size_t total_length = 0;
-  sequence_source.for_each_handle([&](const handle_t& handle)
-  {
-    total_length += 2 * sequence_source.get_length(handle);
-  });
-
   // Store the sequences.
-  this->sequences = StringArray(potential_nodes, total_length, [&](size_t offset) -> std::string
+  this->sequences = StringArray(this->index->sigma() - this->index->firstNode(),
+  [&](size_t offset) -> size_t
+  {
+    gbwt::node_type node = offset + this->index->firstNode();
+    nid_t id = gbwt::Node::id(node);
+    if(!(this->has_node(id))) { return 0; }
+    handle_t handle = sequence_source.get_handle(id, gbwt::Node::is_reverse(node));
+    return sequence_source.get_length(handle);
+  },
+  [&](size_t offset) -> std::string
   {
     gbwt::node_type node = offset + this->index->firstNode();
     nid_t id = gbwt::Node::id(node);
     if(this->has_node(id)) { return std::string(); }
-    bool is_reverse = gbwt::Node::is_reverse(node);
-    handle_t handle = sequence_source.get_handle(id, is_reverse);
+    handle_t handle = sequence_source.get_handle(id, gbwt::Node::is_reverse(node));
     return sequence_source.get_sequence(handle);
   });
 }
@@ -153,32 +161,53 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const SequenceSource& sequenc
   // Build real_nodes to support has_node().
   this->determine_real_nodes();
 
-  // Determine the number of nodes and the total length of the sequences.
-  size_t potential_nodes = this->index->sigma() - this->index->firstNode();
-  size_t total_length = 0;
-  for(gbwt::node_type node = this->index->firstNode(); node < this->index->sigma(); node += 2)
-  {
-    nid_t id = gbwt::Node::id(node);
-    if(this->has_node(id))
-    {
-      total_length += 2 * sequence_source.get_length(sequence_source.get_handle(id, false));
-    }
-  }
-
   // Store the sequences.
-  this->sequences = StringArray(potential_nodes, total_length, [&](size_t offset) -> std::string
+  this->sequences = StringArray(this->index->sigma() - this->index->firstNode(),
+  [&](size_t offset) -> size_t
+  {
+    gbwt::node_type node = offset + this->index->firstNode();
+    nid_t id = gbwt::Node::id(node);
+    if(!(this->has_node(id))) { return 0; }
+    handle_t handle = sequence_source.get_handle(id, false);
+    return sequence_source.get_length(handle);
+  },
+  [&](size_t offset) -> std::string
   {
     gbwt::node_type node = offset + this->index->firstNode();
     nid_t id = gbwt::Node::id(node);
     if(!(this->has_node(id))) { return std::string(); }
     handle_t handle = sequence_source.get_handle(id, false);
     std::string result = sequence_source.get_sequence(handle);
-    if(gbwt::Node::is_reverse(node))
-    {
-      reverse_complement_in_place(result);
-    }
+    if(gbwt::Node::is_reverse(node)) { reverse_complement_in_place(result); }
     return result;
   });
+
+  // Store the node to segment translation.
+  if(sequence_source.uses_translation())
+  {
+    std::vector<std::pair<std::pair<nid_t, nid_t>, view_type>> translations;
+    translations.reserve(sequence_source.segment_translation.size());
+    for(auto iter = sequence_source.segment_translation.begin(); iter != sequence_source.segment_translation.end(); ++iter)
+    {
+      translations.emplace_back(iter->second, str_to_view(iter->first));
+    }
+    gbwt::parallelQuickSort(translations.begin(), translations.end());
+    this->segments = StringArray(translations.size(),
+    [&](size_t offset) -> size_t
+    {
+      return translations[offset].second.second;
+    },
+    [&](size_t offset) -> view_type
+    {
+      return translations[offset].second;
+    });
+    sdsl::sd_vector_builder builder(sequence_source.next_id, translations.size());
+    for(auto& translation : translations)
+    {
+      builder.set_unsafe(translation.first.first);
+    }
+    this->node_to_segment = sdsl::sd_vector<>(builder);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -351,6 +380,86 @@ GBWTGraph::has_edge(const handle_t& left, const handle_t& right) const
 
 //------------------------------------------------------------------------------
 
+bool
+GBWTGraph::has_segment_names() const
+{
+  return !(this->segments.empty());
+}
+
+std::pair<std::string, size_t>
+GBWTGraph::get_segment_name_and_offset(const handle_t& handle) const
+{
+  // If there is no translation, the predecessor is always at the end.
+  nid_t id = this->get_id(handle);
+  auto iter = this->node_to_segment.predecessor(id);
+  if(iter == this->node_to_segment.one_end())
+  {
+    return std::pair<std::string, size_t>(std::to_string(id), 0);
+  }
+
+  // Determine the range of node ids that precede `id` in the given orientation.
+  nid_t start = 0, limit = 0;
+  if(this->get_is_reverse(handle))
+  {
+    auto successor = iter; ++successor;
+    start = id + 1; limit = successor->second;
+  }
+  else
+  {
+    start = iter->first; limit = id;
+  }
+
+  // Determine the offset.
+  size_t offset = 0;
+  for(nid_t i = start; i < limit; i++)
+  {
+    offset += this->get_length(this->get_handle(i, false));
+  }
+
+  return std::pair<std::string, size_t>(this->segments.str(iter->first), offset);
+}
+
+std::string
+GBWTGraph::get_segment_name(const handle_t& handle) const
+{
+  // If there is no translation, the predecessor is always at the end.
+  nid_t id = this->get_id(handle);
+  auto iter = this->node_to_segment.predecessor(id);
+  if(iter == this->node_to_segment.one_end()) { return std::to_string(id); }
+  return this->segments.str(iter->first);
+}
+
+size_t
+GBWTGraph::get_segment_offset(const handle_t& handle) const
+{
+  // If there is no translation, the predecessor is always at the end.
+  nid_t id = this->get_id(handle);
+  auto iter = this->node_to_segment.predecessor(id);
+  if(iter == this->node_to_segment.one_end()) { return 0; }
+
+  // Determine the range of node ids that precede `id` in the given orientation.
+  nid_t start = 0, limit = 0;
+  if(this->get_is_reverse(handle))
+  {
+    auto successor = iter; ++successor;
+    start = id + 1; limit = successor->second;
+  }
+  else
+  {
+    start = iter->first; limit = id;
+  }
+
+  // Determine the offset.
+  size_t offset = 0;
+  for(nid_t i = start; i < limit; i++)
+  {
+    offset += this->get_length(this->get_handle(i, false));
+  }
+  return offset;
+}
+
+//------------------------------------------------------------------------------
+
 uint32_t
 GBWTGraph::get_magic_number() const {
     // Specify what it should look like on the wire
@@ -365,23 +474,34 @@ GBWTGraph::serialize_members(std::ostream& out) const
   out.write(reinterpret_cast<const char*>(&(this->header)), sizeof(Header));
   this->sequences.serialize(out);
   this->real_nodes.serialize(out);
+  this->segments.serialize(out);
+  this->node_to_segment.serialize(out);
 }
 
 void
 GBWTGraph::deserialize_members(std::istream& in)
 {
-  // Load the header.
+  // Load the header and update to the current version.
   in.read(reinterpret_cast<char*>(&(this->header)), sizeof(Header));
+  bool load_translation = (this->header.version == Header::VERSION);
   if(!(this->header.check()))
   {
     std::cerr << "GBWTGraph::deserialize_members(): Invalid or old graph file" << std::endl;
     std::cerr << "GBWTGraph::deserialize_members(): Graph version is " << this->header.version << "; expected " << Header::VERSION << std::endl;
     return;
   }
+  this->header.version = Header::VERSION;
 
-  // Load the rest.
+  // Load the graph.
   this->sequences.deserialize(in);
   this->real_nodes.load(in);
+
+  // Load the translation.
+  if(load_translation)
+  {
+    this->segments.deserialize(in);
+    this->node_to_segment.load(in);
+  }
 }
 
 void

--- a/include/gbwtgraph/cached_gbwtgraph.h
+++ b/include/gbwtgraph/cached_gbwtgraph.h
@@ -112,13 +112,46 @@ public:
     More efficient reimplementations.
   */
 
-  /// Get the number of edges on the right (go_left = false) or left (go_left
-  /// = true) side of the given handle.
+  // Get the number of edges on the right (go_left = false) or left (go_left
+  // = true) side of the given handle.
   virtual size_t get_degree(const handle_t& handle, bool go_left) const;
 
-  /// Returns true if there is an edge that allows traversal from the left
-  /// handle to the right handle.
+  // Returns true if there is an edge that allows traversal from the left
+  // handle to the right handle.
   virtual bool has_edge(const handle_t& left, const handle_t& right) const;
+
+//------------------------------------------------------------------------------
+
+  /*
+    Preliminary interface for SegmentHandleGraph.
+  */
+
+public:
+
+  // Returns `true` if the graph contains a translation from node ids to segment names.
+  virtual bool has_segment_names() const { return this->graph->has_segment_names(); }
+
+  // Returns (GFA segment name, starting offset in the same orientation) for the handle.
+  // If there is no translation, returns ("node id", 0).
+  virtual std::pair<std::string, size_t> get_segment_name_and_offset(const handle_t& handle) const
+  {
+    return this->graph->get_segment_name_and_offset(handle);
+  }
+
+  // Returns the name of the original GFA segment corresponding to the handle.
+  // If there is no translation, returns the node id as a string.
+  virtual std::string get_segment_name(const handle_t& handle) const
+  {
+    return this->graph->get_segment_name(handle);
+  }
+
+  // Returns the starting offset in the original GFA segment corresponding to the handle
+  // in the same orientation as the handle.
+  // If there is no translation, returns 0.
+  virtual size_t get_segment_offset(const handle_t& handle) const
+  {
+    return this->graph->get_segment_offset(handle);
+  }
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -181,8 +181,9 @@ void reverse_complement_in_place(std::string& seq);
 //------------------------------------------------------------------------------
 
 /*
-  A class that maps handles to strings. This can be used as a sequence source in
-  GBWTGraph construction.
+  An intermediate representation for building GBWTGraph from GFA. This class maps
+  node ids to sequences and stores the translation from segment names to (ranges of)
+  node ids.
 
   Nodes can be added with add_node(id, sequence) or translated from GFA segments
   with translate_segment(name, sequence, max_bp). These two approaches must not
@@ -216,44 +217,38 @@ public:
     return iter->second;
   }
 
-  bool has_node(nid_t node_id) const
+  bool has_node(nid_t id) const
   {
-    return (this->nodes.find(this->get_handle(node_id, false)) != this->nodes.end());
+    return (this->nodes.find(id) != this->nodes.end());
   }
 
   size_t get_node_count() const { return this->nodes.size(); }
 
-  // This is compatible with GBWTGraph.
-  handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const
+  size_t get_length(nid_t id) const
   {
-    return handlegraph::number_bool_packing::pack(node_id, is_reverse);
-  }
-
-  size_t get_length(const handle_t& handle) const
-  {
-    auto iter = this->nodes.find(handle);
+    auto iter = this->nodes.find(id);
     if(iter == this->nodes.end()) { return 0; }
     return iter->second.second;
   }
 
-  std::string get_sequence(const handle_t& handle) const
+  std::string get_sequence(nid_t id) const
   {
-    auto iter = this->nodes.find(handle);
+    auto iter = this->nodes.find(id);
     if(iter == this->nodes.end()) { return ""; }
     const char* ptr = this->sequences.data() + iter->second.first;
     return std::string(ptr, ptr + iter->second.second);
   }
 
-  view_type get_sequence_view(const handle_t& handle) const
+  view_type get_sequence_view(nid_t id) const
   {
-    auto iter = this->nodes.find(handle);
+    auto iter = this->nodes.find(id);
     if(iter == this->nodes.end()) { return view_type(nullptr, 0); }
     const char* ptr = this->sequences.data() + iter->second.first;
     return view_type(ptr, iter->second.second);
   }
 
   // (offset, length) for the node sequence.
-  std::unordered_map<handle_t, std::pair<size_t, size_t>> nodes;
+  std::unordered_map<nid_t, std::pair<size_t, size_t>> nodes;
   std::vector<char> sequences;
 
   // If segment translation is enabled, this translates a segment identifier

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -286,6 +286,7 @@ public:
   bool empty() const { return (this->size() == 0); }
   size_t length() const { return this->sequences.size(); }
   size_t length(size_t i) const { return (this->offsets[i + 1] - this->offsets[i]); }
+  size_t length(size_t start, size_t limit) const { return (this->offsets[limit] - this->offsets[start]); }
 
   std::string str(size_t i) const
   {

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -39,6 +39,12 @@ using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
 // This is a quick replacement to std::string_view from C++17.
 typedef std::pair<const char*, size_t> view_type;
 
+inline view_type
+str_to_view(const std::string& str)
+{
+  return view_type(str.data(), str.length());
+}
+
 //------------------------------------------------------------------------------
 
 // Some tools may not work with nodes longer than this.
@@ -60,7 +66,7 @@ struct Version
   constexpr static size_t MINOR_VERSION     = 5;
   constexpr static size_t PATCH_VERSION     = 0;
 
-  constexpr static size_t GRAPH_VERSION     = 1;
+  constexpr static size_t GRAPH_VERSION     = 2;
   constexpr static size_t MINIMIZER_VERSION = 7;
 };
 
@@ -270,8 +276,8 @@ class StringArray
 public:
   StringArray() : offsets(1, 0) {}
   StringArray(const std::vector<std::string>& source);
-  StringArray(size_t n, size_t total_length, const std::function<view_type(size_t)>& get);
-  StringArray(size_t n, size_t total_length, const std::function<std::string(size_t)>& get);
+  StringArray(size_t n, const std::function<size_t(size_t)>& length, const std::function<view_type(size_t)>& sequence);
+  StringArray(size_t n, const std::function<size_t(size_t)>& length, const std::function<std::string(size_t)>& sequence);
 
   void swap(StringArray& another);
 

--- a/path_cover.cpp
+++ b/path_cover.cpp
@@ -518,7 +518,7 @@ path_cover_gbwt(const HandleGraph& graph, size_t n, size_t k, gbwt::size_type ba
   // GBWT construction parameters. Adjust the batch size down for small graphs.
   // We will also set basic metadata: n samples with each component as a separate contig.
   gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-  gbwt::size_type node_width = gbwt::bit_length(gbwt::Node::encode(graph.max_node_id(), true));
+  gbwt::size_type node_width = sdsl::bits::length(gbwt::Node::encode(graph.max_node_id(), true));
   batch_size = std::min(batch_size, static_cast<gbwt::size_type>(2 * n * (graph.get_node_count() + components.size())));
   gbwt::GBWTBuilder builder(node_width, batch_size, sample_interval);
   builder.index.addMetadata();
@@ -555,7 +555,7 @@ local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index, size_t n, si
   // GBWT construction parameters. Adjust the batch size down for small graphs.
   // We will also set basic metadata: n samples with each component as a separate contig.
   gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-  gbwt::size_type node_width = gbwt::bit_length(gbwt::Node::encode(graph.max_node_id(), true));
+  gbwt::size_type node_width = sdsl::bits::length(gbwt::Node::encode(graph.max_node_id(), true));
   batch_size = std::min(batch_size, static_cast<gbwt::size_type>(2 * n * (graph.get_node_count() + components.size())));
   gbwt::GBWTBuilder builder(node_width, batch_size, sample_interval);
   builder.index.addMetadata();
@@ -617,7 +617,7 @@ augment_gbwt(const HandleGraph& graph, gbwt::DynamicGBWT& index, size_t n, size_
 
   // GBWT construction parameters. Adjust the batch size down for small graphs.
   gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-  gbwt::size_type node_width = gbwt::bit_length(gbwt::Node::encode(graph.max_node_id(), true));
+  gbwt::size_type node_width = sdsl::bits::length(gbwt::Node::encode(graph.max_node_id(), true));
   batch_size = std::min(batch_size, static_cast<gbwt::size_type>(2 * n * (graph.get_node_count() + components.size())));
   gbwt::GBWTBuilder builder(node_width, batch_size, sample_interval);
   builder.swapIndex(index);

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -65,7 +65,7 @@ build_gbwt_index()
   {
     for(auto node : path)
     {
-      node_width = std::max(node_width, gbwt::bit_length(gbwt::Node::encode(node, true)));
+      node_width = std::max(node_width, gbwt::size_type(sdsl::bits::length(gbwt::Node::encode(node, true))));
     }
     total_length += 2 * (path.size() + 1);
   }
@@ -93,7 +93,7 @@ build_gbwt_index_with_ref()
   {
     for(auto node : path)
     {
-      node_width = std::max(node_width, gbwt::bit_length(gbwt::Node::encode(node, true)));
+      node_width = std::max(node_width, gbwt::size_type(sdsl::bits::length(gbwt::Node::encode(node, true))));
     }
     total_length += 2 * (path.size() + 1);
   }

--- a/tests/test_cached_gbwtgraph.cpp
+++ b/tests/test_cached_gbwtgraph.cpp
@@ -87,8 +87,7 @@ TEST_F(GraphOperations, Sequences)
     if(!(this->cached_graph.has_node(id))) { continue; }
     handle_t gbwt_fw = this->cached_graph.get_handle(id, false);
     handle_t gbwt_rev = this->cached_graph.get_handle(id, true);
-    handle_t source_fw = this->source.get_handle(id, false);
-    std::string source_str = this->source.get_sequence(source_fw);
+    std::string source_str = this->source.get_sequence(id);
     EXPECT_EQ(this->cached_graph.get_length(gbwt_fw), source_str.length()) << "Wrong forward length at node " << id;
     EXPECT_EQ(this->cached_graph.get_sequence(gbwt_fw), source_str) << "Wrong forward sequence at node " << id;
     std::string source_rev = reverse_complement(source_str);

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -81,6 +81,14 @@ TEST_F(GraphOperations, EmptyGraph)
   EXPECT_EQ(empty_graph.get_node_count(), static_cast<size_t>(0)) << "Empty graph contains nodes";
 }
 
+TEST_F(GraphOperations, FromHandleGraph)
+{
+  GBWTGraph copy(this->index, this->graph);
+  ASSERT_EQ(copy.header, this->graph.header) << "Invalid header";
+  ASSERT_EQ(copy.sequences, this->graph.sequences) << "Invalid sequences";
+  ASSERT_EQ(copy.real_nodes, this->graph.real_nodes) << "Invalid real_nodes";
+}
+
 TEST_F(GraphOperations, CorrectNodes)
 {
   ASSERT_EQ(this->graph.get_node_count(), this->correct_nodes.size()) << "Wrong number of nodes";

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -117,10 +117,9 @@ TEST_F(GraphOperations, Sequences)
   {
     handle_t gbwt_fw = this->graph.get_handle(id, false);
     handle_t gbwt_rev = this->graph.get_handle(id, true);
-    handle_t source_fw = this->source.get_handle(id, false);
-    EXPECT_EQ(this->graph.get_length(gbwt_fw), this->source.get_length(source_fw)) << "Wrong forward length at node " << id;
-    EXPECT_EQ(this->graph.get_sequence(gbwt_fw), this->source.get_sequence(source_fw)) << "Wrong forward sequence at node " << id;
-    std::string source_rev = reverse_complement(this->source.get_sequence(source_fw));
+    EXPECT_EQ(this->graph.get_length(gbwt_fw), this->source.get_length(id)) << "Wrong forward length at node " << id;
+    EXPECT_EQ(this->graph.get_sequence(gbwt_fw), this->source.get_sequence(id)) << "Wrong forward sequence at node " << id;
+    std::string source_rev = reverse_complement(this->source.get_sequence(id));
     EXPECT_EQ(this->graph.get_length(gbwt_rev), source_rev.length()) << "Wrong reverse length at node " << id;
     EXPECT_EQ(this->graph.get_sequence(gbwt_rev), source_rev) << "Wrong reverse sequence at node " << id;
   }

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -79,19 +79,22 @@ TEST_F(GraphOperations, EmptyGraph)
   SequenceSource empty_source;
   GBWTGraph empty_graph(empty_index, empty_source);
   EXPECT_EQ(empty_graph.get_node_count(), static_cast<size_t>(0)) << "Empty graph contains nodes";
+  EXPECT_FALSE(empty_graph.has_segment_names()) << "Empty graph has segment names";
 }
 
 TEST_F(GraphOperations, FromHandleGraph)
 {
   GBWTGraph copy(this->index, this->graph);
-  ASSERT_EQ(copy.header, this->graph.header) << "Invalid header";
-  ASSERT_EQ(copy.sequences, this->graph.sequences) << "Invalid sequences";
-  ASSERT_EQ(copy.real_nodes, this->graph.real_nodes) << "Invalid real_nodes";
+  EXPECT_EQ(copy.header, this->graph.header) << "Invalid header";
+  EXPECT_EQ(copy.sequences, this->graph.sequences) << "Invalid sequences";
+  EXPECT_EQ(copy.real_nodes, this->graph.real_nodes) << "Invalid real_nodes";
+  EXPECT_FALSE(copy.has_segment_names()) << "Got segment names from HandleGraph";
 }
 
 TEST_F(GraphOperations, CorrectNodes)
 {
   ASSERT_EQ(this->graph.get_node_count(), this->correct_nodes.size()) << "Wrong number of nodes";
+  EXPECT_FALSE(this->graph.has_segment_names()) << "Should not have segment names";
   EXPECT_EQ(this->graph.min_node_id(), *(this->correct_nodes.begin())) << "Wrong minimum node id";
   EXPECT_EQ(this->graph.max_node_id(), *(this->correct_nodes.rbegin())) << "Wrong maximum node id";
   for(nid_t id = this->graph.min_node_id(); id <= this->graph.max_node_id(); id++)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -20,10 +20,9 @@ public:
     for(const node_type& node : truth)
     {
       ASSERT_TRUE(source.has_node(node.first)) << "Node id " << node.first << " is missing from the sequence source";
-      handle_t handle = source.get_handle(node.first, false);
-      EXPECT_EQ(source.get_length(handle), node.second.length()) << "Invalid sequence length for node " << node.first;
-      EXPECT_EQ(source.get_sequence(handle), node.second) << "Invalid sequence for node " << node.first;
-      view_type view = source.get_sequence_view(handle);
+      EXPECT_EQ(source.get_length(node.first), node.second.length()) << "Invalid sequence length for node " << node.first;
+      EXPECT_EQ(source.get_sequence(node.first), node.second) << "Invalid sequence for node " << node.first;
+      view_type view = source.get_sequence_view(node.first);
       EXPECT_EQ(std::string(view.first, view.second), node.second) << "Invalid sequence view for node " << node.first;
     }
   }

--- a/utils.cpp
+++ b/utils.cpp
@@ -153,22 +153,28 @@ SequenceSource::translate_segment(const std::string& name, view_type sequence, s
 
 StringArray::StringArray(const std::vector<std::string>& source)
 {
-  size_t total_length = 0;
-  for(const std::string& s : source) { total_length += s.length(); }
-  *this = StringArray(source.size(), total_length, [&source](size_t i) -> view_type
+  *this = StringArray(source.size(),
+  [&source](size_t i) -> size_t
   {
-    return view_type(source[i].data(), source[i].length());
+    return source[i].length();
+  },
+  [&source](size_t i) -> view_type
+  {
+    return str_to_view(source[i]);
   });
 }
 
-StringArray::StringArray(size_t n, size_t total_length, const std::function<view_type(size_t)>& get) :
-  offsets(n + 1, 0, sdsl::bits::length(total_length))
+StringArray::StringArray(size_t n, const std::function<size_t(size_t)>& length, const std::function<view_type(size_t)>& sequence)
 {
+  size_t total_length = 0;
+  for(size_t i = 0; i < n; i++) { total_length += length(i); }
   this->sequences.reserve(total_length);
+  this->offsets = sdsl::int_vector<0>(n + 1, total_length, sdsl::bits::length(total_length));
+
   size_t total = 0;
   for(size_t i = 0; i < n; i++)
   {
-    view_type view = get(i);
+    view_type view = sequence(i);
     this->sequences.insert(this->sequences.end(), view.first, view.first + view.second);
     this->offsets[i] = total;
     total += view.second;
@@ -176,14 +182,17 @@ StringArray::StringArray(size_t n, size_t total_length, const std::function<view
   this->offsets[n] = total;
 }
 
-StringArray::StringArray(size_t n, size_t total_length, const std::function<std::string(size_t)>& get) :
-  offsets(n + 1, 0, sdsl::bits::length(total_length))
+StringArray::StringArray(size_t n, const std::function<size_t(size_t)>& length, const std::function<std::string(size_t)>& sequence)
 {
+  size_t total_length = 0;
+  for(size_t i = 0; i < n; i++) { total_length += length(i); }
   this->sequences.reserve(total_length);
+  this->offsets = sdsl::int_vector<0>(n + 1, total_length, sdsl::bits::length(total_length));
+
   size_t total = 0;
   for(size_t i = 0; i < n; i++)
   {
-    std::string str = get(i);
+    std::string str = sequence(i);
     this->sequences.insert(this->sequences.end(), str.begin(), str.end());
     this->offsets[i] = total;
     total += str.length();

--- a/utils.cpp
+++ b/utils.cpp
@@ -110,25 +110,23 @@ SequenceSource::swap(SequenceSource& another)
 }
 
 void
-SequenceSource::add_node(nid_t node_id, const std::string& sequence)
+SequenceSource::add_node(nid_t id, const std::string& sequence)
 {
   if(sequence.empty()) { return; }
-  handle_t handle = this->get_handle(node_id, false);
-  if(this->nodes.find(handle) != this->nodes.end()) { return; }
+  if(this->nodes.find(id) != this->nodes.end()) { return; }
   size_t offset = this->sequences.size();
   this->sequences.insert(this->sequences.end(), sequence.begin(), sequence.end());
-  this->nodes[handle] = std::pair<size_t, size_t>(offset, sequence.length());
+  this->nodes[id] = std::pair<size_t, size_t>(offset, sequence.length());
 }
 
 void
-SequenceSource::add_node(nid_t node_id, view_type sequence)
+SequenceSource::add_node(nid_t id, view_type sequence)
 {
   if(sequence.second == 0) { return; }
-  handle_t handle = this->get_handle(node_id, false);
-  if(this->nodes.find(handle) != this->nodes.end()) { return; }
+  if(this->nodes.find(id) != this->nodes.end()) { return; }
   size_t offset = this->sequences.size();
   this->sequences.insert(this->sequences.end(), sequence.first, sequence.first + sequence.second);
-  this->nodes[handle] = std::pair<size_t, size_t>(offset, sequence.second);
+  this->nodes[id] = std::pair<size_t, size_t>(offset, sequence.second);
 }
 
 void


### PR DESCRIPTION
Implement the preliminary `SegmentHandleGraph` interface. When a `GBWTGraph` is built from a `SequenceSource` with segment to node translation (usually because the GFA has segments with string names or long sequences), the inverse translation will be stored in the graph. Given a handle, the translation returns the corresponding segment name and/or starting offset in the segment.