### PR TITLE
Compressed GBWTGraph format

### DIFF
--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -208,9 +208,17 @@ GBWTGraph::GBWTGraph(const gbwt::GBWT& gbwt_index, const SequenceSource& sequenc
 void
 GBWTGraph::determine_real_nodes()
 {
+  // Sometimes (e.g. in `decompress()`) we call this function after the header already
+  // contains the correct number of nodes.
+  this->header.nodes = 0;
+  if(this->index->empty())
+  {
+    this->real_nodes = sdsl::bit_vector();
+    return;
+  }
+
   size_t potential_nodes = this->index->sigma() - this->index->firstNode();
   this->real_nodes = sdsl::bit_vector(potential_nodes / 2, 0);
-
   for(gbwt::node_type node = this->index->firstNode(); node < this->index->sigma(); node += 2)
   {
     if(!(this->index->empty(node)))

--- a/gbwtgraph.cpp
+++ b/gbwtgraph.cpp
@@ -34,6 +34,7 @@ constexpr std::uint64_t GBWTGraph::Header::OLD_FLAG_MASK;
 // Other class variables.
 
 const std::string GBWTGraph::EXTENSION = ".gg";
+const std::string GBWTGraph::COMPRESSED_EXTENSION = ".gbz";
 
 //------------------------------------------------------------------------------
 

--- a/gfa2gbwt.cpp
+++ b/gfa2gbwt.cpp
@@ -40,12 +40,11 @@ main(int argc, char** argv)
   Config config(argc, argv);
 
   // Initial output.
-  // TODO progress should go to cerr once gbwt has the option for printHeader, printStatistics
   if(config.show_progress)
   {
-    Version::print(std::cout, tool_name);
-    gbwt::printHeader("Base name"); std::cout << config.base_name << std::endl;
-    std::cout << std::endl;
+    Version::print(std::cerr, tool_name);
+    gbwt::printHeader("Base name", std::cerr) << config.base_name << std::endl;
+    std::cerr << std::endl;
   }
 
   // This is the data we are using.
@@ -58,9 +57,9 @@ main(int argc, char** argv)
   {
     if(config.show_progress)
     {
-      std::cout << "Parsing GFA and building GBWT" << std::endl;
-      std::cout << "Path name regex: " << config.parameters.path_name_regex << std::endl;
-      std::cout << "Path name fields: " << config.parameters.path_name_fields << std::endl;
+      std::cerr << "Parsing GFA and building GBWT" << std::endl;
+      std::cerr << "Path name regex: " << config.parameters.path_name_regex << std::endl;
+      std::cerr << "Path name fields: " << config.parameters.path_name_fields << std::endl;
     }
     auto result = gfa_to_gbwt(config.base_name + GFA_EXTENSION, config.parameters);
     if(result.first.get() == nullptr || result.second.get() == nullptr)
@@ -71,7 +70,7 @@ main(int argc, char** argv)
     index.swap(*(result.first));
     if(config.show_progress)
     {
-      std::cout << "Building GBWTGraph" << std::endl;
+      std::cerr << "Building GBWTGraph" << std::endl;
     }
     graph = GBWTGraph(index, *(result.second));
     if(config.translation)
@@ -84,7 +83,7 @@ main(int argc, char** argv)
   {
     if(config.show_progress)
     {
-      std::cout << "Serializing GBWT" << std::endl;
+      std::cerr << "Serializing GBWT" << std::endl;
     }
     std::string gbwt_name = config.base_name + gbwt::GBWT::EXTENSION;
     std::ofstream gbwt_file(gbwt_name, std::ios_base::binary);
@@ -98,7 +97,7 @@ main(int argc, char** argv)
 
     if(config.show_progress)
     {
-      std::cout << "Serializing GBWTGraph" << std::endl;
+      std::cerr << "Serializing GBWTGraph" << std::endl;
     }
     std::string graph_name = config.base_name + GBWTGraph::EXTENSION;
     std::ofstream graph_file(graph_name, std::ios_base::binary);
@@ -115,7 +114,7 @@ main(int argc, char** argv)
   {
     if(config.show_progress)
     {
-      std::cout << "Compressing GBWTGraph" << std::endl;
+      std::cerr << "Compressing GBWTGraph" << std::endl;
     }
     std::string graph_name = config.base_name + GBWTGraph::COMPRESSED_EXTENSION;
     std::ofstream out(graph_name, std::ios_base::binary);
@@ -134,7 +133,7 @@ main(int argc, char** argv)
   {
     if(config.show_progress)
     {
-      std::cout << "Writing translation table" << std::endl;
+      std::cerr << "Writing translation table" << std::endl;
     }
     std::string translation_name = config.base_name + SequenceSource::TRANSLATION_EXTENSION;
     std::ofstream out(translation_name, std::ios_base::binary);
@@ -152,12 +151,11 @@ main(int argc, char** argv)
 
   if(config.show_progress)
   {
-    std::cout << std::endl;
-    gbwt::printStatistics(index, config.base_name);
+    std::cerr << std::endl;
+    gbwt::printStatistics(index, config.base_name, std::cerr);
     double seconds = gbwt::readTimer() - start;
-    std::cout << "gfa2gbwt used " << seconds << " seconds" << std::endl;
-    std::cout << "Memory usage " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB" << std::endl;
-    std::cout << std::endl;
+    std::cerr << "Used " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+    std::cerr << std::endl;
   }
 
   return 0;

--- a/include/gbwtgraph/cached_gbwtgraph.h
+++ b/include/gbwtgraph/cached_gbwtgraph.h
@@ -131,6 +131,13 @@ public:
   // Returns `true` if the graph contains a translation from node ids to segment names.
   virtual bool has_segment_names() const { return this->graph->has_segment_names(); }
 
+  // Returns (GFA segment name, semiopen node id range) containing the node.
+  // If there is no such translation, returns ("id", (id, id + 1)).
+  virtual std::pair<std::string, std::pair<nid_t, nid_t>> get_segment(nid_t id) const
+  {
+    return this->graph->get_segment(id);
+  }
+
   // Returns (GFA segment name, starting offset in the same orientation) for the handle.
   // If there is no translation, returns ("node id", 0).
   virtual std::pair<std::string, size_t> get_segment_name_and_offset(const handle_t& handle) const
@@ -151,6 +158,14 @@ public:
   virtual size_t get_segment_offset(const handle_t& handle) const
   {
     return this->graph->get_segment_offset(handle);
+  }
+
+  // Calls `iteratee` with each segment name and the semiopen interval of node ids
+  // corresponding to it. Stops early if the call returns `false`.
+  // In GBWTGraph, the segments are visited in sorted order by node ids.
+  virtual void for_each_segment(const std::function<bool(const std::string&, std::pair<nid_t, nid_t>)>& iteratee) const
+  {
+    this->graph->for_each_segment(iteratee);
   }
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -96,6 +96,7 @@ public:
   constexpr static size_t CHUNK_SIZE = 1024; // For parallel for_each_handle().
 
   const static std::string EXTENSION; // ".gg"
+  const static std::string COMPRESSED_EXTENSION; // ".gbz"
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -215,6 +215,10 @@ public:
   // Returns `true` if the graph contains a translation from node ids to segment names.
   virtual bool has_segment_names() const;
 
+  // Returns (GFA segment name, semiopen node id range) containing the node.
+  // If there is no such translation, returns ("id", (id, id + 1)).
+  virtual std::pair<std::string, std::pair<nid_t, nid_t>> get_segment(nid_t id) const;
+
   // Returns (GFA segment name, starting offset in the same orientation) for the handle.
   // If there is no translation, returns ("node id", 0).
   virtual std::pair<std::string, size_t> get_segment_name_and_offset(const handle_t& handle) const;
@@ -227,6 +231,11 @@ public:
   // in the same orientation as the handle.
   // If there is no translation, returns 0.
   virtual size_t get_segment_offset(const handle_t& handle) const;
+
+  // Calls `iteratee` with each segment name and the semiopen interval of node ids
+  // corresponding to it. Stops early if the call returns `false`.
+  // In GBWTGraph, the segments are visited in sorted order by node ids.
+  virtual void for_each_segment(const std::function<bool(const std::string&, std::pair<nid_t, nid_t>)>& iteratee) const;
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,6 +6,7 @@
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
+#include <sdsl/sd_vector.hpp>
 
 #include <functional>
 #include <iostream>
@@ -180,6 +181,8 @@ void reverse_complement_in_place(std::string& seq);
 
 //------------------------------------------------------------------------------
 
+class StringArray;
+
 /*
   An intermediate representation for building GBWTGraph from GFA. This class maps
   node ids to sequences and stores the translation from segment names to (ranges of)
@@ -199,23 +202,10 @@ public:
 
   void swap(SequenceSource& another);
 
+//------------------------------------------------------------------------------
+
   void add_node(nid_t node_id, const std::string& sequence);
   void add_node(nid_t node_id, view_type sequence);
-
-  // Take a GFA segment (name, sequence). If the segment has not been translated
-  // yet, break it into nodes of at most max_length bp each and assign them the
-  // next unused node ids.
-  void translate_segment(const std::string& name, view_type sequence, size_t max_length);
-
-  bool uses_translation() const { return !(this->segment_translation.empty()); }
-
-  // Returns a semiopen range of node ids.
-  std::pair<nid_t, nid_t> get_translation(const std::string& segment_name) const
-  {
-    auto iter = this->segment_translation.find(segment_name);
-    if(iter == this->segment_translation.end()) { return std::pair<nid_t, nid_t>(0, 0); }
-    return iter->second;
-  }
 
   bool has_node(nid_t id) const
   {
@@ -246,6 +236,28 @@ public:
     const char* ptr = this->sequences.data() + iter->second.first;
     return view_type(ptr, iter->second.second);
   }
+
+//------------------------------------------------------------------------------
+
+  // Take a GFA segment (name, sequence). If the segment has not been translated
+  // yet, break it into nodes of at most max_length bp each and assign them the
+  // next unused node ids.
+  void translate_segment(const std::string& name, view_type sequence, size_t max_length);
+
+  bool uses_translation() const { return !(this->segment_translation.empty()); }
+
+  // Returns a semiopen range of node ids.
+  std::pair<nid_t, nid_t> get_translation(const std::string& segment_name) const
+  {
+    auto iter = this->segment_translation.find(segment_name);
+    if(iter == this->segment_translation.end()) { return std::pair<nid_t, nid_t>(0, 0); }
+    return iter->second;
+  }
+
+  // Returns `StringArray` of segment names and `sd_vector<>` mapping node ids to names.
+  std::pair<StringArray, sdsl::sd_vector<>> invert_translation() const;
+
+//------------------------------------------------------------------------------
 
   // (offset, length) for the node sequence.
   std::unordered_map<nid_t, std::pair<size_t, size_t>> nodes;

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -291,6 +291,9 @@ public:
   void serialize(std::ostream& out) const;
   void deserialize(std::istream& in);
 
+  void compress(std::ostream& out) const;
+  void decompress(std::istream& in);
+
   bool operator==(const StringArray& another) const;
   bool operator!=(const StringArray& another) const;
 

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -16,6 +16,7 @@ namespace
 
 //------------------------------------------------------------------------------
 
+typedef gbwtgraph::view_type view_type;
 typedef std::pair<gbwtgraph::nid_t, std::string> node_type;
 typedef std::pair<std::string, std::pair<gbwtgraph::nid_t, gbwtgraph::nid_t>> translation_type;
 
@@ -107,17 +108,32 @@ build_gbwt_index_with_ref()
 }
 
 inline void
-build_source(gbwtgraph::SequenceSource& source)
+build_source(gbwtgraph::SequenceSource& source, bool with_translation = false)
 {
-  source.add_node(1, "G");
-  source.add_node(2, "A");
-  source.add_node(3, "T");
-  source.add_node(4, "GGG");
-  source.add_node(5, "T");
-  source.add_node(6, "A");
-  source.add_node(7, "C");
-  source.add_node(8, "A");
-  source.add_node(9, "A");
+  if(with_translation)
+  {
+    std::string seq = "GATGGGTACAA";
+    source.translate_segment("s1", view_type(seq.data() + 0, 1), 3);
+    source.translate_segment("s2", view_type(seq.data() + 1, 1), 3);
+    source.translate_segment("s3", view_type(seq.data() + 2, 1), 3);
+    source.translate_segment("s4", view_type(seq.data() + 3, 4), 3);
+    source.translate_segment("s5", view_type(seq.data() + 7, 1), 3);
+    source.translate_segment("s6", view_type(seq.data() + 8, 1), 3);
+    source.translate_segment("s7", view_type(seq.data() + 9, 1), 3);
+    source.translate_segment("s8", view_type(seq.data() + 10, 1), 3);
+  }
+  else
+  {
+    source.add_node(1, "G");
+    source.add_node(2, "A");
+    source.add_node(3, "T");
+    source.add_node(4, "GGG");
+    source.add_node(5, "T");
+    source.add_node(6, "A");
+    source.add_node(7, "C");
+    source.add_node(8, "A");
+    source.add_node(9, "A");
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/tests/test_gfa.cpp
+++ b/tests/test_gfa.cpp
@@ -41,7 +41,8 @@ public:
 
   void check_graph(const GBWTGraph& gfa_graph, const GBWTGraph* truth) const
   {
-    ASSERT_EQ(gfa_graph.header, truth->header) << "Graph headers are not identical";
+    // Only check node counts. Headers may be different due to flags that are out of
+    // scope for this test.
     ASSERT_EQ(gfa_graph.get_node_count(), truth->get_node_count()) << "Node counts are not identical";
 
     truth->for_each_handle([&](const handle_t& handle)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -37,6 +37,23 @@ public:
       EXPECT_EQ(source.get_translation(translation.first), translation.second) << "Invalid translation for " << translation.first;
     }
   }
+
+  void check_inverse_translation(const SequenceSource& source) const
+  {
+    auto result = source.invert_translation();
+    ASSERT_EQ(result.first.size(), source.segment_translation.size()) << "Invalid number of segments in inverse translation";
+    ASSERT_EQ(result.second.size(), source.next_id) << "Invalid number of nodes in inverse translation";
+    ASSERT_EQ(result.first.size(), result.second.ones()) << "Inconsistent number of segments in inverse translation";
+    auto iter = result.second.one_begin();
+    for(size_t i = 0; i < result.first.size(); i++)
+    {
+      std::string segment = result.first.str(i);
+      std::pair<nid_t, nid_t> translation = source.get_translation(segment);
+      EXPECT_EQ(nid_t(iter->second), translation.first) << "Invalid start for segment " << segment;
+      ++iter;
+      EXPECT_EQ(nid_t(iter->second), translation.second) << "Invalid limit for segment " << segment;
+    }
+  }
 };
 
 TEST_F(SourceTest, EmptySource)
@@ -47,6 +64,7 @@ TEST_F(SourceTest, EmptySource)
 
   this->check_nodes(source, nodes);
   this->check_translation(source, translation);
+  this->check_inverse_translation(source);
 }
 
 TEST_F(SourceTest, AddNodes)
@@ -70,6 +88,7 @@ TEST_F(SourceTest, AddNodes)
 
   this->check_nodes(source, nodes);
   this->check_translation(source, translation);
+  this->check_inverse_translation(source);
 }
 
 TEST_F(SourceTest, TranslateSegments)
@@ -117,6 +136,7 @@ TEST_F(SourceTest, TranslateSegments)
 
   this->check_nodes(source, nodes);
   this->check_translation(source, translation);  
+  this->check_inverse_translation(source);
 }
 
 //------------------------------------------------------------------------------

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -42,7 +42,7 @@ public:
   {
     auto result = source.invert_translation();
     ASSERT_EQ(result.first.size(), source.segment_translation.size()) << "Invalid number of segments in inverse translation";
-    ASSERT_EQ(result.second.size(), source.next_id) << "Invalid number of nodes in inverse translation";
+    ASSERT_EQ(result.second.size(), size_t(source.next_id)) << "Invalid number of nodes in inverse translation";
     ASSERT_EQ(result.first.size(), result.second.ones()) << "Inconsistent number of segments in inverse translation";
     auto iter = result.second.one_begin();
     for(size_t i = 0; i < result.first.size(); i++)
@@ -205,9 +205,28 @@ TEST_F(StringArrayTest, SerializeEmpty)
   std::ifstream in(filename, std::ios_base::binary);
   copy.deserialize(in);
   in.close();
-  gbwt::TempFile::remove(filename);
-
   ASSERT_EQ(copy, original) << "Serialization changed the empty array";
+
+  gbwt::TempFile::remove(filename);
+}
+
+TEST_F(StringArrayTest, CompressEmpty)
+{
+  std::vector<std::string> truth;
+  StringArray original(truth);
+
+  std::string filename = gbwt::TempFile::getName("string-array");
+  std::ofstream out(filename, std::ios_base::binary);
+  original.compress(out);
+  out.close();
+
+  StringArray copy;
+  std::ifstream in(filename, std::ios_base::binary);
+  copy.decompress(in);
+  in.close();
+  ASSERT_EQ(copy, original) << "Serialization changed the empty array";
+
+  gbwt::TempFile::remove(filename);
 }
 
 TEST_F(StringArrayTest, SerializeNonEmpty)
@@ -230,9 +249,34 @@ TEST_F(StringArrayTest, SerializeNonEmpty)
   std::ifstream in(filename, std::ios_base::binary);
   copy.deserialize(in);
   in.close();
-  gbwt::TempFile::remove(filename);
-
   ASSERT_EQ(copy, original) << "Serialization changed the non-empty array";
+
+  gbwt::TempFile::remove(filename);
+}
+
+TEST_F(StringArrayTest, CompressNonEmpty)
+{
+  std::vector<std::string> truth
+  {
+    "first",
+    "second",
+    "third",
+    "fourth"
+  };
+  StringArray original(truth);
+
+  std::string filename = gbwt::TempFile::getName("string-array");
+  std::ofstream out(filename, std::ios_base::binary);
+  original.compress(out);
+  out.close();
+
+  StringArray copy;
+  std::ifstream in(filename, std::ios_base::binary);
+  copy.decompress(in);
+  in.close();
+  ASSERT_EQ(copy, original) << "Serialization changed the non-empty array";
+
+  gbwt::TempFile::remove(filename);
 }
 
 //------------------------------------------------------------------------------

--- a/utils.cpp
+++ b/utils.cpp
@@ -206,7 +206,7 @@ StringArray::StringArray(size_t n, const std::function<size_t(size_t)>& length, 
   size_t total_length = 0;
   for(size_t i = 0; i < n; i++) { total_length += length(i); }
   this->sequences.reserve(total_length);
-  this->offsets = sdsl::int_vector<0>(n + 1, total_length, sdsl::bits::length(total_length));
+  this->offsets = sdsl::int_vector<0>(n + 1, 0, sdsl::bits::length(total_length));
 
   size_t total = 0;
   for(size_t i = 0; i < n; i++)
@@ -224,7 +224,7 @@ StringArray::StringArray(size_t n, const std::function<size_t(size_t)>& length, 
   size_t total_length = 0;
   for(size_t i = 0; i < n; i++) { total_length += length(i); }
   this->sequences.reserve(total_length);
-  this->offsets = sdsl::int_vector<0>(n + 1, total_length, sdsl::bits::length(total_length));
+  this->offsets = sdsl::int_vector<0>(n + 1, 0, sdsl::bits::length(total_length));
 
   size_t total = 0;
   for(size_t i = 0; i < n; i++)


### PR DESCRIPTION
A compressed GBWTGraph format that stores the GBWT and the graph in the same file. The GBWT is not compressed further, while the graph uses some simple space-saving ideas:

* Node sequences are stored only for the forward orientation.
* The bitvector marking the real nodes is not stored at all. It can be rebuilt when loading the graph.
* String arrays use alphabet compaction and bit packing. This typically means 3 bits/character for node sequences and 4 bits/character for segment names.
* The arrays storing offsets in the string arrays are compressed as `sdsl::sd_vector<>`.

`gfa2gbwt` can build both plain and compressed GBWTGraph as well as convert between the two formats.