### PR TITLE
GBZ format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ gfa2gbwt
 test_algorithms
 test_cached_gbwtgraph
 test_gbwtgraph
+test_gbz
 test_gfa
 test_index
 test_minimizer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,21 @@ add_dependencies(test_gbwtgraph gbwtgraph)
 target_include_directories(test_gbwtgraph PUBLIC ${gbwtgraph_tests_INCLUDE})
 target_link_libraries(test_gbwtgraph ${gbwtgraph_tests_LIBS})
 
+add_executable(test_gbz
+  ${CMAKE_SOURCE_DIR}/tests/test_gbz.cpp
+  ${CMAKE_SOURCE_DIR}/algorithms.cpp
+  ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
+  ${CMAKE_SOURCE_DIR}/gfa.cpp
+  ${CMAKE_SOURCE_DIR}/internal.cpp
+  ${CMAKE_SOURCE_DIR}/minimizer.cpp
+  ${CMAKE_SOURCE_DIR}/utils.cpp
+  ${CMAKE_SOURCE_DIR}/path_cover.cpp)
+add_dependencies(test_gbz gbwtgraph)
+target_include_directories(test_gbz PUBLIC ${gbwtgraph_tests_INCLUDE})
+target_link_libraries(test_gbz ${gbwtgraph_tests_LIBS})
+
 add_executable(test_gfa
   ${CMAKE_SOURCE_DIR}/tests/test_gfa.cpp
   ${CMAKE_SOURCE_DIR}/algorithms.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(gbwtgraph STATIC
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -141,6 +142,7 @@ add_executable(gfa2gbwt
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -164,6 +166,7 @@ add_executable(test_algorithms
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -178,6 +181,7 @@ add_executable(test_cached_gbwtgraph
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -192,6 +196,7 @@ add_executable(test_gbwtgraph
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -206,6 +211,7 @@ add_executable(test_gfa
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -220,6 +226,7 @@ add_executable(test_minimizer
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -234,6 +241,7 @@ add_executable(test_path_cover
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp
@@ -248,6 +256,7 @@ add_executable(test_utils
   ${CMAKE_SOURCE_DIR}/algorithms.cpp
   ${CMAKE_SOURCE_DIR}/cached_gbwtgraph.cpp
   ${CMAKE_SOURCE_DIR}/gbwtgraph.cpp
+  ${CMAKE_SOURCE_DIR}/gbz.cpp
   ${CMAKE_SOURCE_DIR}/gfa.cpp
   ${CMAKE_SOURCE_DIR}/internal.cpp
   ${CMAKE_SOURCE_DIR}/minimizer.cpp

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 CXX_FLAGS=$(MY_CXX_FLAGS) $(PARALLEL_FLAGS) $(MY_CXX_OPT_FLAGS) -Iinclude -I$(INC_DIR)
 
 HEADERS=$(wildcard include/gbwtgraph/*.h)
-LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gfa.o internal.o minimizer.o path_cover.o utils.o)
+LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o internal.o minimizer.o path_cover.o utils.o)
 LIBRARY=$(BUILD_LIB)/libgbwtgraph.a
 
 PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt)

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -40,12 +40,30 @@ The first two fields are 32-bit unsigned little-endian integers for consistency 
 Current file format version is 1.
 Flags are not used in version 1.
 
+### GBWT / GFA paths
+
+If the GBWT does not contain metadata with path names, each original path in the GBWT corresponds to a P-line in GFA.
+The integer identifier of each original path is used as the `PathName` field.
+
+Otherwise the original paths for sample `_gbwt_ref` are assumed to be reference paths that correspond to GFA P-lines.
+Each reference path must have a different contig identifier in the GBWT path name.
+The corresponding contig name is used as the `PathName` field.
+
+Paths for all other samples are assumed to be haplotypes that correspond to GFA W-lines.
+GBWT path name fields map to GFA W-line fields in the following way:
+
+* The sample name corresponding to `sample` maps to `SampleId`.
+* The contig name corresponding to `contig` maps to `SeqId`.
+* `phase` maps to `HapIndex`.
+* `fragment` maps to `SeqStart` (`SeqEnd` can be derived from `fragment` and the path itself).
+
+If the GBWT metadata does not contain sample (contig) names, the integer identifier of the sample (contig) is used instead.
+
 ## GBWTGraph
 
 **GBWTGraph** represents a bidirected sequence graph induced by a set of paths.
 It uses a GBWT index for graph topology and for storing the paths.
 The GBWT must be bidirectional.
-If the GBWT contains metadata with path names and sample names, paths for sample `_gbwt_ref` are assumed to be reference paths.
 
 Serialization format for GBWTGraph:
 

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,22 +1,51 @@
-# Simple-SDS serialization format
+# GBZ file format
 
-Version 3. Updated 2021-05-12.
+GBZ version 1, GBWTGraph version 3. Updated 2021-05-25.
 
 ## Basics
 
-This document specifies the portable simple-sds serialization format for GBWTGraph.
-It is an alternative to the old file format based on SDSL data structures.
+This document specifies the GBZ file format for storing GFA with many paths.
+It includes a portable simple-sds serialization format for GBWTGraph as an alternative to the old SDSL-based format.
 The format builds upon the data structures described in:
 
 * <https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md>
 * <https://github.com/jltsiren/gbwt/blob/master/SERIALIZATION.md>
 
+## GBZ
+
+**GBZ** is a space-efficient binary format for a subset of [GFA1](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md) with many paths.
+It ignores optional GFA fields and assumes that there are no overlaps or containments.
+The format builds upon the simple-sds formats for serializing the GBWT and the GBWTGraph.
+
+GBZ file format:
+
+1. GBZ header
+2. Tags
+3. GBWT
+4. GBWTGraph
+
+**Tags** are stored in the same format as in the GBWT.
+Key `source` indicates the implementation that generated the file.
+The original implementation corresponds to value `jltsiren/gbwtgraph`.
+
+### GBZ Header
+
+**GBZ header** is a 16-byte (2-element) structure with the following fields:
+
+1. `tag`: Value `0x205A4247` as a 32-bit integer.
+2. `version`: File format version as a 32-bit integer.
+3. `flags`: Binary flags as an element.
+
+The first two fields are 32-bit unsigned little-endian integers for consistency with the other headers.
+Current file format version is 1.
+Flags are not used in version 1.
+
 ## GBWTGraph
 
 **GBWTGraph** represents a bidirected sequence graph induced by a set of paths.
 It uses a GBWT index for graph topology and for storing the paths.
-The GBWT must be bidirectional and contain metadata with path names.
-Paths with sample name `_gbwt_ref` are assumed to be reference paths.
+The GBWT must be bidirectional.
+If the GBWT contains metadata with path names and sample names, paths for sample `_gbwt_ref` are assumed to be reference paths.
 
 Serialization format for GBWTGraph:
 
@@ -24,10 +53,6 @@ Serialization format for GBWTGraph:
 2. Tags
 3. Sequences
 4. Node-to-segment translation
-
-**Tags** are stored in the same format as in the GBWT.
-Key `source` indicates the GBWTGraph implementation used for serializing the graph.
-The original implementation corresponds to value `jltsiren/gbwtgraph`.
 
 ### GBWTGraph header
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -78,7 +78,6 @@ public:
     constexpr static std::uint64_t OLD_FLAG_MASK = 0x0000;
 
     Header();
-    void sanitize();
     bool check() const;
 
     void set_version() { this->version = VERSION; }

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -91,16 +91,15 @@ public:
     bool operator!=(const Header& another) const { return !(this->operator==(another)); }
   };
 
-  const gbwt::GBWT*                  index;
+  const gbwt::GBWT* index;
 
-  Header                             header;
-  std::map<std::string, std::string> tags;
-  gbwt::StringArray                  sequences;
-  sdsl::bit_vector                   real_nodes;
+  Header            header;
+  gbwt::StringArray sequences;
+  sdsl::bit_vector  real_nodes;
 
   // Segment to node translation. Node `v` maps to segment `node_to_segment.rank(v)`.
-  gbwt::StringArray                  segments;
-  sdsl::sd_vector<>                  node_to_segment;
+  gbwt::StringArray segments;
+  sdsl::sd_vector<> node_to_segment;
 
   constexpr static size_t CHUNK_SIZE = 1024; // For parallel for_each_handle().
 
@@ -387,9 +386,6 @@ private:
 
   // Throws sdsl::simple_sds::InvalidData if the checks fail.
   void sanity_checks();
-
-  void reset_tags();
-  void add_source();
 
   size_t node_offset(gbwt::node_type node) const { return node - this->index->firstNode(); }
   size_t node_offset(const handle_t& handle) const { return this->node_offset(handle_to_node(handle)); }

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -1,0 +1,103 @@
+#ifndef GBWTGRAPH_GBZ_H
+#define GBWTGRAPH_GBZ_H
+
+#include <gbwtgraph/gbwtgraph.h>
+
+/*
+  gbz.h: GBZ file format.
+*/
+
+namespace gbwtgraph
+{
+
+//------------------------------------------------------------------------------
+
+/*
+  GBZ file format wrapper, as specified in SERIALIZATION.md. The wrapper owns the
+  GBWT index and the GBWTGraph.
+
+  File format versions:
+
+    1  The initial version.
+*/
+
+class GBZ
+{
+public:
+  GBZ();
+  GBZ(const GBZ& source);
+  GBZ(GBZ&& source);
+  ~GBZ();
+
+  // Build GBZ from the structures returned by `gfa_to_gbwt()`.
+  // Resets the pointers to `nullptr`.
+  // Throws `std::invalid_argument` if a pointer is null and `InvalidGBWT` if the
+  // GBWT is not bidirectional.
+  GBZ(std::unique_ptr<gbwt::GBWT>& index, std::unique_ptr<SequenceSource>& source);
+
+  // Build GBZ from a GBWT index and a `HandleGraph`.
+  // Resets the GBWT pointer to `nullptr`.
+  // Throws `std::invalid_argument` if the pointer is null and `InvalidGBWT` if the
+  // GBWT is not bidirectional.
+  GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source);
+
+  // Sets the GBWT pointer in the graph.
+  // This may be necessary if the `graph` member is manipulated directly.
+  void set_gbwt();
+
+  void swap(GBZ& another);
+  GBZ& operator=(const GBZ& source);
+  GBZ& operator=(GBZ&& source);
+
+  struct Header
+  {
+    std::uint32_t tag, version;
+    std::uint64_t flags;
+
+    constexpr static std::uint32_t TAG = 0x205A4247; // "GBZ "
+    constexpr static std::uint32_t VERSION = Version::GBZ_VERSION;
+
+    constexpr static std::uint64_t FLAG_MASK = 0x0000;
+
+    Header();
+    bool check() const;
+
+    void set_version() { this->version = VERSION; }
+
+    void set(std::uint64_t flag) { this->flags |= flag; }
+    void unset(std::uint64_t flag) { this->flags &= ~flag; }
+    bool get(std::uint64_t flag) const { return (this->flags & flag); }
+
+    bool operator==(const Header& another) const;
+    bool operator!=(const Header& another) const { return !(this->operator==(another)); }
+  };
+
+  Header     header;
+  gbwt::Tags tags;
+  gbwt::GBWT index;
+  GBWTGraph  graph;
+
+  const static std::string EXTENSION; // ".gbz"
+
+  // Serialize the the GBZ into the output stream in the simple-sds format.
+  void simple_sds_serialize(std::ostream& out) const;
+
+  // Deserialize or decompress the GBZ from the input stream.
+  // Throws sdsl::simple_sds::InvalidData if sanity checks fail and `InvalidGBWT`
+  // if the GBWT index is not bidirectional.
+  void simple_sds_load(std::istream& in);
+
+  // Returns the size of the serialized structure in elements.
+  size_t simple_sds_size() const;
+
+private:
+  void copy(const GBZ& source);
+  void reset_tags();
+  void add_source();
+};
+
+//------------------------------------------------------------------------------
+
+} // namespace gbwtgraph
+
+#endif // GBWTGRAPH_GBZ_H

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -41,6 +41,10 @@ public:
   // GBWT is not bidirectional.
   GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source);
 
+  // Build GBZ from a GBWT index and a sequence source.
+  // Throws `InvalidGBWT` if the GBWT is not bidirectional.
+  GBZ(const gbwt::GBWT& index, const SequenceSource& source);
+
   // Sets the GBWT pointer in the graph.
   // This may be necessary if the `graph` member is manipulated directly.
   void set_gbwt();
@@ -48,6 +52,8 @@ public:
   void swap(GBZ& another);
   GBZ& operator=(const GBZ& source);
   GBZ& operator=(GBZ&& source);
+
+//------------------------------------------------------------------------------
 
   struct Header
   {
@@ -71,6 +77,8 @@ public:
     bool operator==(const Header& another) const;
     bool operator!=(const Header& another) const { return !(this->operator==(another)); }
   };
+
+//------------------------------------------------------------------------------
 
   Header     header;
   gbwt::Tags tags;

--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -104,7 +104,8 @@ gfa_to_gbwt(const std::string& gfa_filename, const GFAParsingParameters& paramet
 
   4. W-lines for other paths, ordered by path id.
 
-  Throws `InvalidGBWT` if the GBWT index does not contain sufficient metadata.
+  If the GBWT does not contain path names, all GBWT paths will be written as P-lines
+  instead.
 */
 void gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, bool show_progress = false);
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -81,6 +81,7 @@ struct Version
   constexpr static size_t MINOR_VERSION     = 6;
   constexpr static size_t PATCH_VERSION     = 0;
 
+  constexpr static size_t GBZ_VERSION       = 1;
   constexpr static size_t GRAPH_VERSION     = 3;
   constexpr static size_t MINIMIZER_VERSION = 7;
 

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -51,6 +51,7 @@ GBZ::Header::operator==(const Header& another) const
 GBZ::GBZ()
 {
   this->add_source();
+  this->set_gbwt();
 }
 
 GBZ::GBZ(const GBZ& source)
@@ -154,6 +155,12 @@ GBZ::GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source)
   this->add_source();
   this->index = std::move(*index); index.reset();
   this->graph = GBWTGraph(this->index, source);
+}
+
+GBZ::GBZ(const gbwt::GBWT& index, const SequenceSource& source) :
+  index(index), graph(this->index, source)
+{
+  this->add_source();
 }
 
 void

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -1,0 +1,207 @@
+#include <gbwtgraph/gbz.h>
+
+namespace gbwtgraph
+{
+
+//------------------------------------------------------------------------------
+
+// Numerical class constants.
+
+constexpr std::uint32_t GBZ::Header::TAG;
+constexpr std::uint32_t GBZ::Header::VERSION;
+
+constexpr std::uint64_t GBZ::Header::FLAG_MASK;
+
+//------------------------------------------------------------------------------
+
+// Other class variables.
+
+const std::string GBZ::EXTENSION = ".gbz";
+
+//------------------------------------------------------------------------------
+
+GBZ::Header::Header() :
+  tag(TAG), version(VERSION),
+  flags(0)
+{
+}
+
+bool
+GBZ::Header::check() const
+{
+  if(this->tag != TAG) { return false; }
+  switch(this->version)
+  {
+  case VERSION:
+    return ((this->flags & FLAG_MASK) == this->flags);
+  default:
+    return false;
+  }
+}
+
+bool
+GBZ::Header::operator==(const Header& another) const
+{
+  return (this->tag == another.tag && this->version == another.version &&
+          this->flags == another.flags);
+}
+
+//------------------------------------------------------------------------------
+
+GBZ::GBZ()
+{
+  this->add_source();
+}
+
+GBZ::GBZ(const GBZ& source)
+{
+  this->copy(source);
+}
+
+GBZ::GBZ(GBZ&& source)
+{
+  *this = std::move(source);
+}
+
+GBZ::~GBZ()
+{
+}
+
+void
+GBZ::swap(GBZ& another)
+{
+  if(&another == this) { return; }
+
+  std::swap(this->header, another.header);
+  this->tags.swap(another.tags);
+  this->index.swap(another.index);
+  this->graph.swap(another.graph);
+
+  // GBWTGraph did not know that we also swapped the GBWTs.
+  this->set_gbwt();
+  another.set_gbwt();
+}
+
+GBZ&
+GBZ::operator=(const GBZ& source)
+{
+  if(&source != this) { this->copy(source); }
+  return *this;
+}
+
+GBZ&
+GBZ::operator=(GBZ&& source)
+{
+  if(&source != this)
+  {
+    this->header = std::move(source.header);
+    this->tags = std::move(source.tags);
+    this->index = std::move(source.index);
+    this->graph = std::move(source.graph);
+
+    // GBWTGraph did not know that we also moved the GBWT.
+    this->set_gbwt();
+  }
+  return *this;
+}
+
+void
+GBZ::copy(const GBZ& source)
+{
+  this->header = source.header;
+  this->tags = source.tags;
+  this->index = source.index;
+  this->graph = source.graph;
+
+  // Use the local copy of the GBWT.
+  this->set_gbwt();
+}
+
+void
+GBZ::reset_tags()
+{
+  this->tags.clear();
+  this->add_source();
+}
+
+void
+GBZ::add_source()
+{
+  this->tags.set(Version::SOURCE_KEY, Version::SOURCE_VALUE);
+}
+
+//------------------------------------------------------------------------------
+
+GBZ::GBZ(std::unique_ptr<gbwt::GBWT>& index, std::unique_ptr<SequenceSource>& source)
+{
+  if(index == nullptr || source == nullptr)
+  {
+    throw std::invalid_argument("GBZ: Index and sequence source must be non-null");
+  }
+
+  this->add_source();
+  this->index = std::move(*index); index.reset();
+  this->graph = GBWTGraph(this->index, *source); source.reset();
+}
+
+GBZ::GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source)
+{
+  if(index == nullptr)
+  {
+    throw std::invalid_argument("GBZ: Index must be non-null");
+  }
+
+  this->add_source();
+  this->index = std::move(*index); index.reset();
+  this->graph = GBWTGraph(this->index, source);
+}
+
+void
+GBZ::set_gbwt()
+{
+  this->graph.set_gbwt(this->index);
+}
+
+//------------------------------------------------------------------------------
+
+void
+GBZ::simple_sds_serialize(std::ostream& out) const
+{
+  sdsl::simple_sds::serialize_value(this->header, out);
+  this->tags.simple_sds_serialize(out);
+  this->index.simple_sds_serialize(out);
+  this->graph.simple_sds_serialize(out);
+}
+
+void
+GBZ::simple_sds_load(std::istream& in)
+{
+  this->header = sdsl::simple_sds::load_value<Header>(in);
+  if(!(this->header.check()))
+  {
+    throw sdsl::simple_sds::InvalidData("GBZ: Invalid header");
+  }
+
+  // Load the tags and update the source to this library.
+  // We could also check if the source was already this library, but we have no
+  // uses for that information at the moment.
+  this->tags.simple_sds_load(in);
+  this->add_source();
+
+  this->index.simple_sds_load(in);
+  this->graph.simple_sds_load(in, this->index);
+}
+
+size_t
+GBZ::simple_sds_size() const
+{
+  size_t result = sdsl::simple_sds::value_size(this->header);
+  result += this->tags.simple_sds_size();
+  result += this->index.simple_sds_size();
+  result += this->graph.simple_sds_size();
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace gbwtgraph

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -1485,7 +1485,7 @@ gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, bool show_progress)
 {
   if(!(graph.index->hasMetadata() && graph.index->metadata.hasPathNames()))
   {
-    throw InvalidGBWT("gbwt_to_gfa: The GBWT index must contain metadata with path  names");
+    throw InvalidGBWT("gbwt_to_gfa: The GBWT index must contain metadata with path names");
   }
 
   // Cache segment names.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,7 +33,7 @@ endif
 CXX_FLAGS=$(MY_CXX_FLAGS) $(PARALLEL_FLAGS) $(MY_CXX_OPT_FLAGS) -I$(MAIN_DIR)/include -I$(INC_DIR)
 
 HEADERS=$(wildcard $(GBWT_DIR)/include/gbwt/*.h)
-PROGRAMS=test_algorithms test_cached_gbwtgraph test_gbwtgraph test_gfa test_index test_minimizer test_path_cover test_utils
+PROGRAMS=test_utils test_gbwtgraph test_cached_gbwtgraph test_gfa test_gbz test_minimizer test_index test_algorithms test_path_cover
 
 .PHONY: all clean test
 all:$(PROGRAMS)

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -423,6 +423,7 @@ TEST_F(GraphSerialization, CompressEmpty)
   ASSERT_EQ(bytes, expected_size) << "Invalid file size";
   duplicate_graph.simple_sds_load(in, *(empty_graph.index));
   in.close();
+  this->check_graph(duplicate_graph, empty_graph);
 
   gbwt::TempFile::remove(filename);
 }

--- a/tests/test_gbz.cpp
+++ b/tests/test_gbz.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <gbwtgraph/gbz.h>
+
+#include "shared.h"
+
+using namespace gbwtgraph;
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+
+class GBZSerialization : public ::testing::Test
+{
+public:
+  void check_gbz(const GBZ& gbz, const GBZ& truth) const
+  {
+    // GBZ
+    ASSERT_EQ(gbz.header, truth.header) << "GBZ: Invalid header";
+    ASSERT_EQ(gbz.tags, truth.tags) << "GBZ: Invalid tags";
+
+    // GBWT
+    ASSERT_EQ(gbz.index.size(), truth.index.size()) << "GBWT: Invalid size";
+    ASSERT_EQ(gbz.index.sequences(), truth.index.sequences()) << "GBWT: Invalid number of sequences";
+    ASSERT_EQ(gbz.index.sigma(), truth.index.sigma()) << "GBWT: Invalid alphabet size";
+    ASSERT_EQ(gbz.index.effective(), truth.index.effective()) << "GBWT: Invalid effective alphabet size";
+    ASSERT_EQ(gbz.index.samples(), truth.index.samples()) << "GBWT: Invalid number of samples";
+
+    // Graph
+    ASSERT_EQ(gbz.graph.header, truth.graph.header) << "Graph: Invalid header";
+    ASSERT_EQ(gbz.graph.sequences, truth.graph.sequences) << "Graph: Invalid sequences";
+    ASSERT_EQ(gbz.graph.real_nodes, truth.graph.real_nodes) << "Graph: Invalid real nodes";
+    ASSERT_EQ(gbz.graph.segments, truth.graph.segments) << "Graph: Invalid segments";
+    ASSERT_EQ(gbz.graph.node_to_segment, truth.graph.node_to_segment) << "Graph: Invalid node-to-segment mapping";
+  }
+};
+
+TEST_F(GBZSerialization, Empty)
+{
+  GBZ empty;
+  size_t expected_size = empty.simple_sds_size() * sizeof(sdsl::simple_sds::element_type);
+  std::string filename = gbwt::TempFile::getName("gbz");
+  sdsl::simple_sds::serialize_to(empty, filename);
+
+  GBZ duplicate;
+  std::ifstream in(filename, std::ios_base::binary);
+  size_t bytes = gbwt::fileSize(in);
+  ASSERT_EQ(bytes, expected_size) << "Invalid file size";
+  duplicate.simple_sds_load(in);
+  in.close();
+  this->check_gbz(duplicate, empty);
+
+  gbwt::TempFile::remove(filename);
+}
+
+TEST_F(GBZSerialization, NonEmpty)
+{
+  SequenceSource source; build_source(source);
+  GBZ original(build_gbwt_index(), source);
+  size_t expected_size = original.simple_sds_size() * sizeof(sdsl::simple_sds::element_type);
+  std::string filename = gbwt::TempFile::getName("gbz");
+  sdsl::simple_sds::serialize_to(original, filename);
+
+  GBZ duplicate;
+  std::ifstream in(filename, std::ios_base::binary);
+  size_t bytes = gbwt::fileSize(in);
+  ASSERT_EQ(bytes, expected_size) << "Invalid file size";
+  duplicate.simple_sds_load(in);
+  in.close();
+  this->check_gbz(duplicate, original);
+
+  gbwt::TempFile::remove(filename);
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace


### PR DESCRIPTION
Some changes to the GBZ format:

* There is now a proper header.
* GBWTGraph tags are now in GBZ instead.

Also, GBWT metadata is no longer required in GBZ or for GFA extraction. If there is no metadata, each original path becomes a GFA P-line with the identifier as name.