### PR TITLE
Add NamedNodeBackTranslation

### DIFF
--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -43,7 +43,7 @@ namespace gbwtgraph
     1  The initial version.
 */
 
-class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph, public SegmentHandleGraph
+class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph 
 {
 public:
   GBWTGraph(); // Call (deserialize() and set_gbwt()) or simple_sds_load() before using the graph.
@@ -316,7 +316,7 @@ protected:
 //------------------------------------------------------------------------------
 
   /*
-    SegmentHandleGraph interface.
+    WIP SegmentHandleGraph interface.
 
     NOTE: The implementation stores the translations also for segments that were not used
     on any path. Because the corresponding nodes are missing from the graph, the methods
@@ -325,25 +325,43 @@ protected:
 
 public:
 
-  // Returns `true` if the graph contains a translation from node ids to segment names.
+  /// Returns `true` if the graph contains a translation from node ids to segment names.
   virtual bool has_segment_names() const;
 
-  // Returns (GFA segment name, semiopen node id range) containing the handle.
-  // If there is no such translation, returns ("id", (id, id + 1)).
+  /// Returns (GFA segment name, semiopen node id range) containing the handle.
+  /// If there is no such translation, returns ("id", (id, id + 1)).
   virtual std::pair<std::string, std::pair<nid_t, nid_t>> get_segment(const handle_t& handle) const;
 
-  // Returns (GFA segment name, starting offset in the same orientation) for the handle.
-  // If there is no translation, returns ("id", 0).
+  /// Returns (GFA segment name, starting offset in the same orientation) for the handle.
+  /// If there is no translation, returns ("id", 0).
   virtual std::pair<std::string, size_t> get_segment_name_and_offset(const handle_t& handle) const;
 
-  // Returns the name of the original GFA segment corresponding to the handle.
-  // If there is no translation, returns the node id as a string.
+  /// Returns the name of the original GFA segment corresponding to the handle.
+  /// If there is no translation, returns the node id as a string.
   virtual std::string get_segment_name(const handle_t& handle) const;
 
-  // Returns the starting offset in the original GFA segment corresponding to the handle
-  // in the same orientation as the handle.
-  // If there is no translation, returns 0.
+  /// Returns the starting offset in the original GFA segment corresponding to the handle
+  /// in the same orientation as the handle.
+  /// If there is no translation, returns 0.
   virtual size_t get_segment_offset(const handle_t& handle) const;
+  
+  /// Calls `iteratee` with each segment name as a string, and the semiopen
+  /// interval of node ids corresponding to it as a std::pair of nid_t
+  /// values. Stops early if the call returns `false`.
+  /// Returns false if iteration was stopped, and true otherwise.
+  template<typename Iteratee>
+  bool for_each_segment(const Iteratee& iteratee) const {
+    return for_each_segment_impl(handlegraph::BoolReturningWrapper<Iteratee>::wrap(iteratee));
+  }
+
+  /// Calls `iteratee` with each inter-segment edge (as an edge_t) and the
+  /// corresponding segment names in the canonical orientation (as two
+  /// strings). Stops early if the call returns `false`.
+  /// Returns false if iteration was stopped, and true otherwise.
+  template<typename Iteratee>
+  bool for_each_link(const Iteratee& iteratee) const {
+    return for_each_link_impl(handlegraph::BoolReturningWrapper<Iteratee>::wrap(iteratee));
+  }
 
 protected:
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -43,7 +43,7 @@ namespace gbwtgraph
     1  The initial version.
 */
 
-class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph, public SegmentSpace
+class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph, public SegmentHandleGraph
 {
 public:
   GBWTGraph(); // Call (deserialize() and set_gbwt()) or simple_sds_load() before using the graph.
@@ -316,7 +316,7 @@ protected:
 //------------------------------------------------------------------------------
 
   /*
-    SegmentSpace interface.
+    SegmentHandleGraph interface.
 
     NOTE: The implementation stores the translations also for segments that were not used
     on any path. Because the corresponding nodes are missing from the graph, the methods
@@ -328,40 +328,33 @@ public:
   // Returns `true` if the graph contains a translation from node ids to segment names.
   virtual bool has_segment_names() const;
 
-  // Returns (GFA segment name, semiopen node id range) containing the given node.
+  // Returns (GFA segment name, semiopen node id range) containing the handle.
   // If there is no such translation, returns ("id", (id, id + 1)).
-  virtual std::pair<std::string, std::pair<nid_t, nid_t>> get_segment(const nid_t& node_id) const;
+  virtual std::pair<std::string, std::pair<nid_t, nid_t>> get_segment(const handle_t& handle) const;
 
-  // Returns (GFA segment name, starting offset in the same orientation) for the given oriented node.
+  // Returns (GFA segment name, starting offset in the same orientation) for the handle.
   // If there is no translation, returns ("id", 0).
-  virtual std::pair<std::string, size_t> get_segment_name_and_offset(const nid_t& node_id, bool is_reverse) const;
+  virtual std::pair<std::string, size_t> get_segment_name_and_offset(const handle_t& handle) const;
 
-  // Returns the name of the original GFA segment corresponding to the given node.
+  // Returns the name of the original GFA segment corresponding to the handle.
   // If there is no translation, returns the node id as a string.
-  virtual std::string get_segment_name(const nid_t& node_id) const;
+  virtual std::string get_segment_name(const handle_t& handle) const;
 
-  // Returns the starting offset in the original GFA segment corresponding to
-  // the given oriented node, in the same orientation.
+  // Returns the starting offset in the original GFA segment corresponding to the handle
+  // in the same orientation as the handle.
   // If there is no translation, returns 0.
-  virtual size_t get_segment_offset(const nid_t& node_id, bool is_reverse) const;
-
-  // Keep the handle-based implementations from the interface
-  using SegmentSpace::get_segment;
-  using SegmentSpace::get_segment_name_and_offset;
-  using SegmentSpace::get_segment_name;
-  using SegmentSpace::get_segment_offset;
+  virtual size_t get_segment_offset(const handle_t& handle) const;
 
 protected:
 
-  /// Calls `iteratee` with each segment name and the semiopen interval of node ids
-  /// corresponding to it. Stops early if the call returns `false`.
-  /// In GBWTGraph, the segments are visited in sorted order by node ids.
+  // Calls `iteratee` with each segment name and the semiopen interval of node ids
+  // corresponding to it. Stops early if the call returns `false`.
+  // In GBWTGraph, the segments are visited in sorted order by node ids.
   virtual bool for_each_segment_impl(const std::function<bool(const std::string&, const std::pair<nid_t, nid_t>&)>& iteratee) const;
 
-  /// Calls `iteratee` with each inter-segment edge and the corresponding segment names
-  /// in the canonical orientation. Stops early if the call returns `false`.
-  /// Ignores the passed graph.
-  virtual bool for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* graph = nullptr) const;
+  // Calls `iteratee` with each inter-segment edge and the corresponding segment names
+  // in the canonical orientation. Stops early if the call returns `false`.
+  virtual bool for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const;
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -43,7 +43,7 @@ namespace gbwtgraph
     1  The initial version.
 */
 
-class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph
+class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph, public SegmentHandleGraph
 {
 public:
   GBWTGraph(); // Call (deserialize() and set_gbwt()) or simple_sds_load() before using the graph.
@@ -316,7 +316,7 @@ protected:
 //------------------------------------------------------------------------------
 
   /*
-    Preliminary interface for SegmentHandleGraph.
+    SegmentHandleGraph interface.
 
     NOTE: The implementation stores the translations also for segments that were not used
     on any path. Because the corresponding nodes are missing from the graph, the methods
@@ -345,14 +345,16 @@ public:
   // If there is no translation, returns 0.
   virtual size_t get_segment_offset(const handle_t& handle) const;
 
+protected:
+
   // Calls `iteratee` with each segment name and the semiopen interval of node ids
   // corresponding to it. Stops early if the call returns `false`.
   // In GBWTGraph, the segments are visited in sorted order by node ids.
-  virtual void for_each_segment(const std::function<bool(const std::string&, std::pair<nid_t, nid_t>)>& iteratee) const;
+  virtual bool for_each_segment_impl(const std::function<bool(const std::string&, const std::pair<nid_t, nid_t>&)>& iteratee) const;
 
   // Calls `iteratee` with each inter-segment edge and the corresponding segment names
   // in the canonical orientation. Stops early if the call returns `false`.
-  virtual void for_each_link(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const;
+  virtual bool for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const;
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -43,7 +43,7 @@ namespace gbwtgraph
     1  The initial version.
 */
 
-class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph 
+class GBWTGraph : public PathHandleGraph, public SerializableHandleGraph, public NamedNodeBackTranslation 
 {
 public:
   GBWTGraph(); // Call (deserialize() and set_gbwt()) or simple_sds_load() before using the graph.
@@ -373,6 +373,23 @@ protected:
   // Calls `iteratee` with each inter-segment edge and the corresponding segment names
   // in the canonical orientation. Stops early if the call returns `false`.
   virtual bool for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const;
+
+//------------------------------------------------------------------------------
+
+  /*
+    NamedNodeBackTranslation interface.
+  */
+
+public:
+
+  /// Translate a node range back to segment space.
+  /// Return value is not defined if no segments exist or the node does not
+  /// exist.
+  virtual std::vector<oriented_node_range_t> translate_back(const oriented_node_range_t& range) const;
+  
+  /// Get a segment name. Return value is not defined if no segments exist or
+  /// if the segment is out of range.
+  virtual std::string get_back_graph_node_name(const nid_t& back_node_id) const;
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,7 +6,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/serializable_handle_graph.hpp>
-#include <handlegraph/segment_space.hpp>
+#include <handlegraph/segment_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
@@ -41,7 +41,7 @@ using edge_t = handlegraph::edge_t;
 
 using HandleGraph = handlegraph::HandleGraph;
 using PathHandleGraph = handlegraph::PathHandleGraph;
-using SegmentSpace = handlegraph::SegmentSpace;
+using SegmentHandleGraph = handlegraph::SegmentHandleGraph;
 using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,7 +6,6 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/serializable_handle_graph.hpp>
-#include <handlegraph/segment_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
@@ -41,7 +40,6 @@ using edge_t = handlegraph::edge_t;
 
 using HandleGraph = handlegraph::HandleGraph;
 using PathHandleGraph = handlegraph::PathHandleGraph;
-using SegmentHandleGraph = handlegraph::SegmentHandleGraph;
 using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,6 +6,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/serializable_handle_graph.hpp>
+#include <handlegraph/segment_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
@@ -40,6 +41,7 @@ using edge_t = handlegraph::edge_t;
 
 using HandleGraph = handlegraph::HandleGraph;
 using PathHandleGraph = handlegraph::PathHandleGraph;
+using SegmentHandleGraph = handlegraph::SegmentHandleGraph;
 using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,6 +6,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/serializable_handle_graph.hpp>
+#include <handlegraph/named_node_back_translation.hpp>
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
@@ -37,10 +38,12 @@ using handle_t = handlegraph::handle_t;
 using path_handle_t = handlegraph::path_handle_t;
 using step_handle_t = handlegraph::step_handle_t;
 using edge_t = handlegraph::edge_t;
+using oriented_node_range_t = handlegraph::oriented_node_range_t;
 
 using HandleGraph = handlegraph::HandleGraph;
 using PathHandleGraph = handlegraph::PathHandleGraph;
 using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
+using NamedNodeBackTranslation = handlegraph::NamedNodeBackTranslation;
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -6,7 +6,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/serializable_handle_graph.hpp>
-#include <handlegraph/segment_handle_graph.hpp>
+#include <handlegraph/segment_space.hpp>
 #include <handlegraph/util.hpp>
 
 #include <sdsl/int_vector.hpp>
@@ -41,7 +41,7 @@ using edge_t = handlegraph::edge_t;
 
 using HandleGraph = handlegraph::HandleGraph;
 using PathHandleGraph = handlegraph::PathHandleGraph;
-using SegmentHandleGraph = handlegraph::SegmentHandleGraph;
+using SegmentSpace = handlegraph::SegmentSpace;
 using SerializableHandleGraph = handlegraph::SerializableHandleGraph;
 
 //------------------------------------------------------------------------------

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -864,10 +864,10 @@ GBWTGraph::get_segment_offset(const handle_t& handle) const
   return offset;
 }
 
-void
-GBWTGraph::for_each_segment(const std::function<bool(const std::string&, std::pair<nid_t, nid_t>)>& iteratee) const
+bool
+GBWTGraph::for_each_segment_impl(const std::function<bool(const std::string&, const std::pair<nid_t, nid_t>&)>& iteratee) const
 {
-  if(!(this->has_segment_names())) { return; }
+  if(!(this->has_segment_names())) { return true; }
 
   auto iter = this->node_to_segment.one_begin();
   while(iter != this->node_to_segment.one_end())
@@ -880,17 +880,18 @@ GBWTGraph::for_each_segment(const std::function<bool(const std::string&, std::pa
     // The corresponding nodes are missing from the graph.
     if(this->has_node(start))
     {
-      if(!iteratee(name, std::make_pair(start, limit))) { return; }
+      if(!iteratee(name, std::make_pair(start, limit))) { return false; }
     }
   }
+  return true;
 }
 
-void
-GBWTGraph::for_each_link(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const
+bool
+GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const
 {
-  if(!(this->has_segment_names())) { return; }
+  if(!(this->has_segment_names())) { return true; }
 
-  this->for_each_segment([&](const std::string& from_segment, std::pair<nid_t, nid_t> nodes) -> bool
+  return this->for_each_segment([&](const std::string& from_segment, std::pair<nid_t, nid_t> nodes) -> bool
   {
     bool keep_going = true;
     // Right edges from forward orienation are canonical if the destination node

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -10,23 +10,6 @@
 
 #include <omp.h>
 
-// Support for unused parameters without warnings.
-// Mangle the parameter name so it can't be used, and suppress the warning.
-// See <https://stackoverflow.com/a/12891181>
-#if __cplusplus >= 201703L
-  // C++17 has a standard attribute for this.
-  // TODO: When we bump up to requiring C++17, replace the macro with this.
-   #define UNUSED(x) UNUSED_ ## x [[maybe_unused]]
-#else
-  #ifdef __GNUC__
-    // We can use a GNU extension for this, in gcc or Clang
-    #define UNUSED(x) UNUSED_ ## x [[gnu::unused]]
-  #else
-    // No attribute, just hide the variable
-    #define UNUSED(x) UNUSED_ ## x
-  #endif
-#endif
-
 namespace gbwtgraph
 {
 
@@ -900,9 +883,11 @@ GBWTGraph::for_each_segment_impl(const std::function<bool(const std::string&, co
 }
 
 bool
-GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* UNUSED(graph)) const
+GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* graph) const
 {
   // Since we are a HandleGraph we ignore the passed graph.
+  // Silence the warning about the unused parameter.
+  graph;
   
   if(!(this->has_segment_names())) { return true; }
 

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -779,14 +779,13 @@ GBWTGraph::has_segment_names() const
 }
 
 std::pair<std::string, std::pair<nid_t, nid_t>>
-GBWTGraph::get_segment(const handle_t& handle) const
+GBWTGraph::get_segment(const nid_t& node_id) const
 {
   // If there is no translation, the predecessor is always at the end.
-  nid_t id = this->get_id(handle);
-  auto iter = this->node_to_segment.predecessor(id);
-  if(!(this->has_node(id)) || iter == this->node_to_segment.one_end())
+  auto iter = this->node_to_segment.predecessor(node_id);
+  if(!(this->has_node(node_id)) || iter == this->node_to_segment.one_end())
   {
-    return std::pair<std::string, std::pair<nid_t, nid_t>>(std::to_string(id), std::make_pair(id, id + 1));
+    return std::pair<std::string, std::pair<nid_t, nid_t>>(std::to_string(node_id), std::make_pair(node_id, node_id + 1));
   }
 
   nid_t start = iter->second;
@@ -798,29 +797,28 @@ GBWTGraph::get_segment(const handle_t& handle) const
 }
 
 std::pair<std::string, size_t>
-GBWTGraph::get_segment_name_and_offset(const handle_t& handle) const
+GBWTGraph::get_segment_name_and_offset(const nid_t& node_id, bool is_reverse) const
 {
   // If there is no translation, the predecessor is always at the end.
-  nid_t id = this->get_id(handle);
-  auto iter = this->node_to_segment.predecessor(id);
-  if(!(this->has_node(id)) || iter == this->node_to_segment.one_end())
+  auto iter = this->node_to_segment.predecessor(node_id);
+  if(!(this->has_node(node_id)) || iter == this->node_to_segment.one_end())
   {
-    return std::pair<std::string, size_t>(std::to_string(id), 0);
+    return std::pair<std::string, size_t>(std::to_string(node_id), 0);
   }
 
-  // Determine the total length of nodes in this segment that precede `id`
+  // Determine the total length of nodes in this segment that precede `node_id`
   // in the given orientation.
   size_t start = 0, limit = 0;
-  if(this->get_is_reverse(handle))
+  if(is_reverse)
   {
     auto successor = iter; ++successor;
-    start = this->node_offset(gbwt::Node::encode(id + 1, false));
+    start = this->node_offset(gbwt::Node::encode(node_id + 1, false));
     limit = this->node_offset(gbwt::Node::encode(successor->second, false));
   }
   else
   {
     start = this->node_offset(gbwt::Node::encode(iter->second, false));
-    limit = this->node_offset(gbwt::Node::encode(id, false));
+    limit = this->node_offset(gbwt::Node::encode(node_id, false));
   }
   size_t offset = this->sequences.length(start, limit) / 2;
 
@@ -828,36 +826,34 @@ GBWTGraph::get_segment_name_and_offset(const handle_t& handle) const
 }
 
 std::string
-GBWTGraph::get_segment_name(const handle_t& handle) const
+GBWTGraph::get_segment_name(const nid_t& node_id) const
 {
   // If there is no translation, the predecessor is always at the end.
-  nid_t id = this->get_id(handle);
-  auto iter = this->node_to_segment.predecessor(id);
-  if(iter == this->node_to_segment.one_end()) { return std::to_string(id); }
+  auto iter = this->node_to_segment.predecessor(node_id);
+  if(iter == this->node_to_segment.one_end()) { return std::to_string(node_id); }
   return this->segments.str(iter->first);
 }
 
 size_t
-GBWTGraph::get_segment_offset(const handle_t& handle) const
+GBWTGraph::get_segment_offset(const nid_t& node_id, bool is_reverse) const
 {
   // If there is no translation, the predecessor is always at the end.
-  nid_t id = this->get_id(handle);
-  auto iter = this->node_to_segment.predecessor(id);
-  if(!(this->has_node(id)) || iter == this->node_to_segment.one_end()) { return 0; }
+  auto iter = this->node_to_segment.predecessor(node_id);
+  if(!(this->has_node(node_id)) || iter == this->node_to_segment.one_end()) { return 0; }
 
-  // Determine the total length of nodes in this segment that precede `id`
+  // Determine the total length of nodes in this segment that precede `node_id`
   // in the given orientation.
   size_t start = 0, limit = 0;
-  if(this->get_is_reverse(handle))
+  if(is_reverse)
   {
     auto successor = iter; ++successor;
-    start = this->node_offset(gbwt::Node::encode(id + 1, false));
+    start = this->node_offset(gbwt::Node::encode(node_id + 1, false));
     limit = this->node_offset(gbwt::Node::encode(successor->second, false));
   }
   else
   {
     start = this->node_offset(gbwt::Node::encode(iter->second, false));
-    limit = this->node_offset(gbwt::Node::encode(id, false));
+    limit = this->node_offset(gbwt::Node::encode(node_id, false));
   }
   size_t offset = this->sequences.length(start, limit) / 2;
 
@@ -887,8 +883,12 @@ GBWTGraph::for_each_segment_impl(const std::function<bool(const std::string&, co
 }
 
 bool
-GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee) const
+GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* graph) const
 {
+  // Since we are a HandleGraph we ignore the passed graph.
+  // Silence the warning about the unused parameter.
+  graph;
+  
   if(!(this->has_segment_names())) { return true; }
 
   return this->for_each_segment([&](const std::string& from_segment, std::pair<nid_t, nid_t> nodes) -> bool

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -10,6 +10,23 @@
 
 #include <omp.h>
 
+// Support for unused parameters without warnings.
+// Mangle the parameter name so it can't be used, and suppress the warning.
+// See <https://stackoverflow.com/a/12891181>
+#if __cplusplus >= 201703L
+  // C++17 has a standard attribute for this.
+  // TODO: When we bump up to requiring C++17, replace the macro with this.
+   #define UNUSED(x) UNUSED_ ## x [[maybe_unused]]
+#else
+  #ifdef __GNUC__
+    // We can use a GNU extension for this, in gcc or Clang
+    #define UNUSED(x) UNUSED_ ## x [[gnu::unused]]
+  #else
+    // No attribute, just hide the variable
+    #define UNUSED(x) UNUSED_ ## x
+  #endif
+#endif
+
 namespace gbwtgraph
 {
 
@@ -883,11 +900,9 @@ GBWTGraph::for_each_segment_impl(const std::function<bool(const std::string&, co
 }
 
 bool
-GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* graph) const
+GBWTGraph::for_each_link_impl(const std::function<bool(const edge_t&, const std::string&, const std::string&)>& iteratee, const HandleGraph* UNUSED(graph)) const
 {
   // Since we are a HandleGraph we ignore the passed graph.
-  // Silence the warning about the unused parameter.
-  graph;
   
   if(!(this->has_segment_names())) { return true; }
 


### PR DESCRIPTION
This is meant to work with `libhandlegraph` f99a7b5032dc9c1dbceedcac8ee82a24d1a460c8.

This makes GBWTGraph implement `NamedNodeBackTranslation`, a more general interface that can be used here and by stand-alone translation representations to allow ranges on graph nodes to be mapped to (collections of) ranges on GFA segments.