### PR TITLE
Multithreaded gfa2gbwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ test_utils
 # vim
 \#*
 \.#*
+
+# VSCode
+.vscode

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, 2020 Jouni Siren
+Copyright (c) 2019, 2020, 2021, 2022 Jouni Siren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/gbwtgraph/cached_gbwtgraph.h
+++ b/include/gbwtgraph/cached_gbwtgraph.h
@@ -30,7 +30,7 @@ public:
   CachedGBWTGraph();
   CachedGBWTGraph(const CachedGBWTGraph& source);
   CachedGBWTGraph(CachedGBWTGraph&& source);
-  ~CachedGBWTGraph();
+  virtual ~CachedGBWTGraph();
 
   explicit CachedGBWTGraph(const GBWTGraph& graph);
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -49,7 +49,7 @@ public:
   GBWTGraph(); // Call (deserialize() and set_gbwt()) or simple_sds_load() before using the graph.
   GBWTGraph(const GBWTGraph& source);
   GBWTGraph(GBWTGraph&& source);
-  ~GBWTGraph();
+  virtual ~GBWTGraph();
 
   // Build the graph from another `HandleGraph`.
   GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_source);

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -285,15 +285,14 @@ protected:
 //------------------------------------------------------------------------------
 
   /*
-    SerializableHandleGraph interface.
+    SerializableHandleGraph interface. Serialization / deserialization throws
+    `std::runtime_error` on failure.
   */
 
 public:
 
   // Set the GBWT index used for graph topology and cache reference path information.
   // Call deserialize() before using the graph.
-  // Throws sdsl::simple_sds::InvalidData or `InvalidGBWT` if the sanity checks fail
-  // for the graph or the GBWT, respectively.
   // MUST be called before using the graph if the graph is deserialize()-ed.
   void set_gbwt(const gbwt::GBWT& gbwt_index);
   
@@ -308,8 +307,6 @@ protected:
 
   // Underlying implementation to "deserialize" method.
   // Load the sequences from the istream.
-  // Throws sdsl::simple_sds::InvalidData or `InvalidGBWT` if the sanity checks fail
-  // for the graph or the GBWT, respectively.
   // User must call set_gbwt() before using the graph.
   virtual void deserialize_members(std::istream& in);
 
@@ -394,7 +391,8 @@ public:
 //------------------------------------------------------------------------------
 
   /*
-    GBWTGraph specific interface.
+    GBWTGraph specific interface. Serialization / deserialization throws
+    `std::runtime_error` on failure.
   */
 
 public:
@@ -404,8 +402,6 @@ public:
 
   // Deserialize or decompress the graph from the input stream and set the given
   // GBWT index. Note that the GBWT index is essential for loading the structure.
-  // Throws sdsl::simple_sds::InvalidData if sanity checks fail and `InvalidGBWT`
-  // if the GBWT index is not bidirectional.
   void simple_sds_load(std::istream& in, const gbwt::GBWT& gbwt_index);
 
   // Returns the size of the serialized structure in elements.

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -16,6 +16,8 @@ namespace gbwtgraph
   GBZ file format wrapper, as specified in SERIALIZATION.md. The wrapper owns the
   GBWT index and the GBWTGraph.
 
+  Constructors, serialization, and loading throw `std::runtime_error` on failure.
+
   File format versions:
 
     1  The initial version.
@@ -31,24 +33,18 @@ public:
 
   // Build GBZ from the structures returned by `gfa_to_gbwt()`.
   // Resets the pointers to `nullptr`.
-  // Throws `std::runtime_error` if a pointer is null and `InvalidGBWT` if the
-  // GBWT is not bidirectional.
   GBZ(std::unique_ptr<gbwt::GBWT>& index, std::unique_ptr<SequenceSource>& source);
 
   // Build GBZ from a GBWT index and a `HandleGraph`.
   // Resets the GBWT pointer to `nullptr`.
-  // Throws `std::runtime_error` if the pointer is null and `InvalidGBWT` if the
-  // GBWT is not bidirectional.
   GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source);
 
   // Build GBZ from a GBWT index and a sequence source.
   // Note that the GBZ will store a copy of the GBWT index.
-  // Throws `InvalidGBWT` if the GBWT is not bidirectional.
   GBZ(const gbwt::GBWT& index, const SequenceSource& source);
 
   // Build GBZ from a GBWT index and a `HandleGraph`.
   // Note that the GBZ will store a copy of the GBWT index.
-  // Throws `InvalidGBWT` if the GBWT is not bidirectional.
   GBZ(const gbwt::GBWT& index, const HandleGraph& source);
 
   void swap(GBZ& another);
@@ -98,8 +94,6 @@ public:
   static void simple_sds_serialize(const gbwt::GBWT& index, const GBWTGraph& graph, std::ostream& out);
 
   // Deserialize or decompress the GBZ from the input stream.
-  // Throws sdsl::simple_sds::InvalidData if sanity checks fail and `InvalidGBWT`
-  // if the GBWT index is not bidirectional.
   void simple_sds_load(std::istream& in);
 
   // Returns the size of the serialized structure in elements.

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -31,13 +31,13 @@ public:
 
   // Build GBZ from the structures returned by `gfa_to_gbwt()`.
   // Resets the pointers to `nullptr`.
-  // Throws `std::invalid_argument` if a pointer is null and `InvalidGBWT` if the
+  // Throws `std::runtime_error` if a pointer is null and `InvalidGBWT` if the
   // GBWT is not bidirectional.
   GBZ(std::unique_ptr<gbwt::GBWT>& index, std::unique_ptr<SequenceSource>& source);
 
   // Build GBZ from a GBWT index and a `HandleGraph`.
   // Resets the GBWT pointer to `nullptr`.
-  // Throws `std::invalid_argument` if the pointer is null and `InvalidGBWT` if the
+  // Throws `std::runtime_error` if the pointer is null and `InvalidGBWT` if the
   // GBWT is not bidirectional.
   GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source);
 

--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -70,7 +70,7 @@ struct GFAParsingParameters
     2. There are no containments.
 
   Link lines are ignored, and the edges are instead derived from the paths.
-  If the construction failes, the return value is `(nullptr, nullptr)`.
+  If the construction fails, the function throws `std::runtime_error`.
 
   The construction is done in several passes over a memory-mapped GFA file. The
   function returns the GBWT index and a sequence source for GBWTGraph construction.

--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -71,6 +71,18 @@ struct GFAParsingParameters
 
 //------------------------------------------------------------------------------
 
+struct GFAExtractionParameters
+{
+  // Use this many OpenMP threads for extracting paths and walks. Value 0 is interpreted
+  // as 1.
+  size_t num_threads = 1;
+  size_t threads() const { return std::max(this->num_threads, size_t(1)); }
+
+  bool show_progress = false;
+};
+
+//------------------------------------------------------------------------------
+
 /*
   Build GBWT from GFA P-lines and/or W-lines with the following assumptions:
 
@@ -112,15 +124,16 @@ gfa_to_gbwt(const std::string& gfa_filename, const GFAParsingParameters& paramet
   2. L-lines in canonical order. Edges (from, to) are ordered by tuples
   (id(from), is_reverse(from), id(to), is_reverse(to)). All overlaps are `*`.
 
-  3. P-lines for paths corresponding to sample `REFERENCE_PATH_SAMPLE_NAME`, ordered
-  by path id. All overlaps are `*`.
+  3. P-lines for paths corresponding to sample `REFERENCE_PATH_SAMPLE_NAME`. All
+  overlaps are `*`.
 
-  4. W-lines for other paths, ordered by path id.
+  4. W-lines for other paths.
 
-  If the GBWT does not contain path names, all GBWT paths will be written as P-lines
-  instead.
+  When the GFA is extracted using a single thread, the P-lines and W-lines are
+  ordered by the corresponding GBWT path ids. If the GBWT does not contain path
+  names, all GBWT paths will be written as P-lines.
 */
-void gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, bool show_progress = false);
+void gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, const GFAExtractionParameters& parameters = GFAExtractionParameters());
 
 extern const std::string GFA_EXTENSION; // ".gfa"
 

--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -16,10 +16,11 @@ namespace gbwtgraph
 
 //------------------------------------------------------------------------------
 
-// TODO: Add automatic sanity checks.
+// TODO: Add sanity checks.
 struct GFAParsingParameters
 {
-  // GBWT construction parameters.
+  // GBWT construction parameters. `node_width` and `batch_size` are not validated
+  // at the moment.
   gbwt::size_type node_width = gbwt::WORD_BITS;
   gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE;
   gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL;
@@ -28,9 +29,12 @@ struct GFAParsingParameters
   size_t max_node_length = MAX_NODE_LENGTH;
 
   // To avoid creating too many jobs, combine small consecutive components into jobs
-  // of at most `num_nodes / approximate_num_jobs` nodes.
+  // of at most `num_nodes / approximate_num_jobs` nodes. Value 0 is interpreted as 1.
   constexpr static size_t APPROXIMATE_NUM_JOBS = 32;
   size_t approximate_num_jobs = APPROXIMATE_NUM_JOBS;
+
+  // Try to run this may construction jobs in parallel. Value 0 is interpreted as 1.
+  size_t parallel_jobs = 1;
 
   // Determine GBWT batch size automatically. If the length of the longest path is `N`
   // segments, batch size will be the maximum of the default (100 million) and

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -79,7 +79,7 @@ struct MetadataBuilder
 
   bool ref_path_sample_warning;
 
-  MetadataBuilder(const std::string& path_name_regex, const std::string& path_name_prefix); // FIXME number of jobs
+  MetadataBuilder(const std::string& path_name_regex, const std::string& path_name_prefix);
 
   // Parse a path name using a regex and assign it to the given job.
   // This must not be used with add_walk() or add_reference_path().

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -20,45 +20,6 @@ namespace gbwtgraph
 //------------------------------------------------------------------------------
 
 /*
-  A hash set with string keys. New keys are buffered and inserted in
-  a background thread. The overall logic is similar to `GBWTBuilder`.
-*/
-struct BufferedHashSet
-{
-  BufferedHashSet();
-  ~BufferedHashSet();
-
-  void insert(view_type view)
-  {
-    if(this->input_buffer.size() >= BUFFER_SIZE) { this->flush(); }
-    this->input_buffer.emplace_back(view.first, view.second);
-  }
-
-  // Insert all buffered keys into the hash table.
-  void finish();
-
-  // Buffer up to this many keys.
-  constexpr static size_t BUFFER_SIZE = 4 * 1048576;
-
-  std::unordered_set<std::string> data;
-
-  // New keys are buffered here.
-  std::vector<std::string> input_buffer;
-
-  // The insertion thread uses this data.
-  std::vector<std::string> internal_buffer;
-  std::thread              worker;
-
-  BufferedHashSet(const BufferedHashSet&) = delete;
-  BufferedHashSet& operator=(const BufferedHashSet&) = delete;
-
-private:
-  void flush();
-};
-
-//------------------------------------------------------------------------------
-
-/*
   A buffered TSV file writer.
 */
 struct TSVWriter
@@ -113,10 +74,7 @@ public:
   virtual ~GFAGraph() {}
 
   // Insert a new node with the given sequence.
-  void insert_node(nid_t node_id, view_type sequence)
-  {
-    this->nodes[node_id] = { sequence, {}, {} };
-  }
+  void insert_node(nid_t node_id, view_type sequence);
 
   // Insert a new edge and return `true` if the insertion was successful.
   // Returns `false` if the endpoints do not exist.

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -59,6 +59,9 @@ struct TSVWriter
 
 /*
   A structure for building GBWT metadata.
+
+  Constructor and the methods for handling paths/walks throw `std::runtime_error`
+  on failure.
 */
 struct MetadataBuilder
 {
@@ -76,20 +79,19 @@ struct MetadataBuilder
 
   bool ref_path_sample_warning;
 
-  // Throws `std::runtime_error` on failure.
   MetadataBuilder(const std::string& path_name_regex, const std::string& path_name_prefix);
 
-  // Parse a path name using a regex. Returns true if successful.
+  // Parse a path name using a regex.
   // This must not be used with add_walk() or add_reference_path().
-  bool parse(const std::string& name);
+  void parse(const std::string& name);
 
-  // Add a path based on walk metadata. Returns true if successful.
+  // Add a path based on walk metadata.
   // This must not be used with parse().
-  bool add_walk(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start);
+  void add_walk(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start);
 
-  // Add a reference path. Returns true if successful.
+  // Add a reference path.
   // This must not be used with parse().
-  bool add_reference_path(const std::string& name);
+  void add_reference_path(const std::string& name);
 
   bool empty() const { return this->path_names.empty(); }
 

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -58,6 +58,37 @@ struct TSVWriter
 //------------------------------------------------------------------------------
 
 /*
+  A buffered TSV writer where the buffer grows as necessary and must be flushed
+  explicitly. Intended for multi-threaded situations.
+*/
+struct ManualTSVWriter
+{
+  explicit ManualTSVWriter(std::ostream& out);
+
+  void put(char c) { this->buffer.push_back(c); }
+  void newline() { this->put('\n'); }
+  void newfield() { this->put('\t'); }
+
+  void write(view_type view) { this->buffer.insert(this->buffer.end(), view.first, view.first + view.second); }
+  void write(const std::string& str) { this->write(view_type(str.data(), str.length())); }
+  void write(size_t value)
+  {
+    std::string str = std::to_string(value);
+    this->write(str);
+  }
+
+  void flush();
+
+  // Buffer this many bytes;
+  constexpr static size_t BUFFER_SIZE = 4 * 1048576;
+
+  std::vector<char> buffer;
+  std::ostream&     out;
+};
+
+//------------------------------------------------------------------------------
+
+/*
   A structure for building GBWT metadata.
 
   Constructor and the methods for handling paths/walks throw `std::runtime_error`

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -88,6 +89,129 @@ struct TSVWriter
 
   std::vector<char> buffer;
   std::ostream&     out;
+};
+
+//------------------------------------------------------------------------------
+
+/*
+  A naive HandleGraph implementation that uses sequences from a memory-mapped
+  GFA file.
+*/
+class GFAGraph : public HandleGraph
+{
+public:
+  struct Node
+  {
+    view_type sequence;
+    std::vector<handle_t> predecessors, successors;
+  };
+
+  std::unordered_map<nid_t, Node> nodes;
+  nid_t min_id, max_id;
+
+  GFAGraph() : min_id(std::numeric_limits<nid_t>::max()), max_id(0) {}
+  virtual ~GFAGraph() {}
+
+  // Insert a new node with the given sequence.
+  void insert_node(nid_t node_id, view_type sequence)
+  {
+    this->nodes[node_id] = { sequence, {}, {} };
+  }
+
+  // Insert a new edge and return `true` if the insertion was successful.
+  // Returns `false` if the endpoints do not exist.
+  bool insert_edge(const handle_t& from, const handle_t& to);
+
+  // Remove all duplicate edges.
+  void remove_duplicate_edges();
+
+public:
+
+  // Method to check if a node exists by ID.
+  virtual bool has_node(nid_t node_id) const;
+
+  // Look up the handle for the node with the given ID in the given orientation.
+  virtual handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+
+  // Get the ID from a handle.
+  virtual nid_t get_id(const handle_t& handle) const;
+
+  // Get the orientation of a handle.
+  virtual bool get_is_reverse(const handle_t& handle) const;
+
+  // Invert the orientation of a handle (potentially without getting its ID).
+  virtual handle_t flip(const handle_t& handle) const;
+
+  // Get the length of a node.
+  virtual size_t get_length(const handle_t& handle) const;
+
+  // Get the sequence of a node, presented in the handle's local forward
+  // orientation.
+  virtual std::string get_sequence(const handle_t& handle) const;
+
+  // Returns one base of a handle's sequence, in the orientation of the
+  // handle.
+  virtual char get_base(const handle_t& handle, size_t index) const;
+    
+  // Returns a substring of a handle's sequence, in the orientation of the
+  // handle. If the indicated substring would extend beyond the end of the
+  // handle's sequence, the return value is truncated to the sequence's end.
+  virtual std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
+
+  // Return the number of nodes in the graph.
+  virtual size_t get_node_count() const;
+
+  // Return the smallest ID in the graph, or some smaller number if the
+  // smallest ID is unavailable. Return value is unspecified if the graph is empty.
+  virtual nid_t min_node_id() const;
+
+  // Return the largest ID in the graph, or some larger number if the
+  // largest ID is unavailable. Return value is unspecified if the graph is empty.
+  virtual nid_t max_node_id() const;
+
+protected:
+
+  // Loop over all the handles to next/previous (right/left) nodes. Passes
+  // them to a callback which returns false to stop iterating and true to
+  // continue. Returns true if we finished and false if we stopped early.
+  virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+
+  // Loop over all the nodes in the graph in their local forward
+  // orientations, in their internal stored order. Stop if the iteratee
+  // returns false. Can be told to run in parallel, in which case stopping
+  // after a false return value is on a best-effort basis and iteration
+  // order is not defined. Returns true if we finished and false if we 
+  // stopped early.
+  virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+
+public:
+
+  // Get the number of edges on the right (go_left = false) or left (go_left
+  // = true) side of the given handle.
+  virtual size_t get_degree(const handle_t& handle, bool go_left) const;
+
+public:
+
+  // Returns an iterator to the specified node.
+  std::unordered_map<nid_t, Node>::const_iterator get_node(const handle_t& handle) const
+  {
+    return this->nodes.find(gbwt::Node::id(handle_to_node(handle)));
+  }
+
+  // Returns an iterator to the specified node.
+  std::unordered_map<nid_t, Node>::iterator get_node_mut(const handle_t& handle)
+  {
+    return this->nodes.find(gbwt::Node::id(handle_to_node(handle)));
+  }
+
+  // Convert gbwt::node_type to handle_t.
+  static handle_t node_to_handle(gbwt::node_type node) { return handlegraph::as_handle(node); }
+
+  // Convert handle_t to gbwt::node_type.
+  static gbwt::node_type handle_to_node(const handle_t& handle) { return handlegraph::as_integer(handle); }
+  
+  // Get node sequence as a pointer and length.
+  view_type get_sequence_view(const handle_t& handle) const;
 };
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -293,6 +293,12 @@ public:
     return iter->second;
   }
 
+  // FIXME tests
+  // Translates the segment if translation is in use, or converts the segment
+  // name into an integer `id` and returns `(id, id + 1)` otherwise.
+  // Returns `invalid_translation()` on failure.
+  std::pair<nid_t, nid_t> force_translate(const std::string& segment_name) const;
+
   // Returns `StringArray` of segment names and `sd_vector<>` mapping node ids to names.
   // If `is_present` returns false, the corresponding segment name will be empty.
   std::pair<gbwt::StringArray, sdsl::sd_vector<>> invert_translation(const std::function<bool(std::pair<nid_t, nid_t>)>& is_present) const;

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -270,18 +270,26 @@ public:
 
 //------------------------------------------------------------------------------
 
+  // An empty translation or a translation that does not exist.
+  constexpr static std::pair<nid_t, nid_t> empty_translation()
+  {
+    return std::pair<nid_t, nid_t>(0, 0);
+  }
+
   // Take a GFA segment (name, sequence). If the segment has not been translated
   // yet, break it into nodes of at most max_length bp each and assign them the
-  // next unused node ids.
-  void translate_segment(const std::string& name, view_type sequence, size_t max_length);
+  // next unused node ids. Returns the node id range for the translated segment
+  // or `empty_translation()` on failure.
+  std::pair<nid_t, nid_t> translate_segment(const std::string& name, view_type sequence, size_t max_length);
 
   bool uses_translation() const { return !(this->segment_translation.empty()); }
 
-  // Returns a semiopen range of node ids, or (0, 0) if there is no such segment.
+  // Returns a semiopen range of node ids, or `empty_translation()` if there is
+  // no such segment.
   std::pair<nid_t, nid_t> get_translation(const std::string& segment_name) const
   {
     auto iter = this->segment_translation.find(segment_name);
-    if(iter == this->segment_translation.end()) { return std::pair<nid_t, nid_t>(0, 0); }
+    if(iter == this->segment_translation.end()) { return empty_translation(); }
     return iter->second;
   }
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -271,7 +271,7 @@ public:
 //------------------------------------------------------------------------------
 
   // An empty translation or a translation that does not exist.
-  constexpr static std::pair<nid_t, nid_t> empty_translation()
+  constexpr static std::pair<nid_t, nid_t> invalid_translation()
   {
     return std::pair<nid_t, nid_t>(0, 0);
   }
@@ -279,17 +279,17 @@ public:
   // Take a GFA segment (name, sequence). If the segment has not been translated
   // yet, break it into nodes of at most max_length bp each and assign them the
   // next unused node ids. Returns the node id range for the translated segment
-  // or `empty_translation()` on failure.
+  // or `invalid_translation()` on failure.
   std::pair<nid_t, nid_t> translate_segment(const std::string& name, view_type sequence, size_t max_length);
 
   bool uses_translation() const { return !(this->segment_translation.empty()); }
 
-  // Returns a semiopen range of node ids, or `empty_translation()` if there is
+  // Returns a semiopen range of node ids, or `invalid_translation()` if there is
   // no such segment.
   std::pair<nid_t, nid_t> get_translation(const std::string& segment_name) const
   {
     auto iter = this->segment_translation.find(segment_name);
-    if(iter == this->segment_translation.end()) { return empty_translation(); }
+    if(iter == this->segment_translation.end()) { return invalid_translation(); }
     return iter->second;
   }
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -293,7 +293,6 @@ public:
     return iter->second;
   }
 
-  // FIXME tests
   // Translates the segment if translation is in use, or converts the segment
   // name into an integer `id` and returns `(id, id + 1)` otherwise.
   // Returns `invalid_translation()` on failure.

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -277,7 +277,7 @@ public:
 
   bool uses_translation() const { return !(this->segment_translation.empty()); }
 
-  // Returns a semiopen range of node ids.
+  // Returns a semiopen range of node ids, or (0, 0) if there is no such segment.
   std::pair<nid_t, nid_t> get_translation(const std::string& segment_name) const
   {
     auto iter = this->segment_translation.find(segment_name);

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -150,7 +150,7 @@ GBZ::GBZ(std::unique_ptr<gbwt::GBWT>& index, std::unique_ptr<SequenceSource>& so
 {
   if(index == nullptr || source == nullptr)
   {
-    throw std::invalid_argument("GBZ: Index and sequence source must be non-null");
+    throw std::runtime_error("GBZ: Index and sequence source must be non-null");
   }
 
   this->add_source();
@@ -162,7 +162,7 @@ GBZ::GBZ(std::unique_ptr<gbwt::GBWT>& index, const HandleGraph& source)
 {
   if(index == nullptr)
   {
-    throw std::invalid_argument("GBZ: Index must be non-null");
+    throw std::runtime_error("GBZ: Index must be non-null");
   }
 
   this->add_source();

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -216,44 +216,40 @@ private:
 
 public:
   /*
-    Iterate over the S-lines, calling segment() for all segments. Stops early if segment()
-    returns false.
+    Iterate over the S-lines, calling segment() for all segments.
   */
-  void for_each_segment(const std::function<bool(const std::string& name, view_type sequence)>& segment) const;
+  void for_each_segment(const std::function<void(const std::string& name, view_type sequence)>& segment) const;
 
   /*
-    Iterate over the L-lines, calling link() for all segments. Stops early if segment()
-    returns false.
+    Iterate over the L-lines, calling link() for all segments.
   */
- void for_each_link(const std::function<bool(const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse)>& link) const;
+ void for_each_link(const std::function<void(const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse)>& link) const;
 
   /*
-    Iterate over the file, calling path() for each path. Stops early if path() returns false.
+    Iterate over the file, calling path() for each path.
   */
-  void for_each_path_name(const std::function<bool(const std::string& name)>& path) const;
+  void for_each_path_name(const std::function<void(const std::string& name)>& path) const;
 
   /*
     Iterate over the file, calling path() for each path, path_segment() for
-    each path segment, and finish_path() after parsing each path. Stops early
-    if any call returns false.
+    each path segment, and finish_path() after parsing each path.
   */
-  void for_each_path(const std::function<bool(const std::string& name)>& path,
-                     const std::function<bool(const std::string& name, bool is_reverse)>& path_segment,
-                     const std::function<bool()>& finish_path) const;
+  void for_each_path(const std::function<void(const std::string& name)>& path,
+                     const std::function<void(const std::string& name, bool is_reverse)>& path_segment,
+                     const std::function<void()>& finish_path) const;
 
   /*
-    Iterate over the file, calling walk() for each walk. Stops early if walk() returns false.
+    Iterate over the file, calling walk() for each walk.
   */
-  void for_each_walk_name(const std::function<bool(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk) const;
+  void for_each_walk_name(const std::function<void(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk) const;
 
   /*
     Iterate over the file, calling walk() for each walk, walk_segment() for
-    each walk segment, and finish_walk() after parsing each walk. Stops early
-    if any call returns false.
+    each walk segment, and finish_walk() after parsing each walk.
   */
-  void for_each_walk(const std::function<bool(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk,
-                     const std::function<bool(const std::string& name, bool is_reverse)>& walk_segment,
-                     const std::function<bool()>& finish_walk) const;
+  void for_each_walk(const std::function<void(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk,
+                     const std::function<void(const std::string& name, bool is_reverse)>& walk_segment,
+                     const std::function<void()>& finish_walk) const;
 };
 
 //------------------------------------------------------------------------------
@@ -526,7 +522,7 @@ GFAFile::check_field(const field_type& field, const std::string& field_name, boo
 //------------------------------------------------------------------------------
 
 void
-GFAFile::for_each_segment(const std::function<bool(const std::string& name, view_type sequence)>& segment) const
+GFAFile::for_each_segment(const std::function<void(const std::string& name, view_type sequence)>& segment) const
 {
   for(const char* iter : this->s_lines)
   {
@@ -540,12 +536,12 @@ GFAFile::for_each_segment(const std::function<bool(const std::string& name, view
     // Sequence field.
     field = this->next_field(field);
     view_type sequence = field.view();
-    if(!segment(name, sequence)) { return; }
+    segment(name, sequence);
   }
 }
 
 void
-GFAFile::for_each_link(const std::function<bool(const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse)>& link) const
+GFAFile::for_each_link(const std::function<void(const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse)>& link) const
 {
   for(const char* iter : this->l_lines)
   {
@@ -568,12 +564,12 @@ GFAFile::for_each_link(const std::function<bool(const std::string& from, bool fr
     field = this->next_field(field);
     bool to_is_reverse = field.is_reverse_orientation();
 
-    if(!link(from, from_is_reverse, to, to_is_reverse)) { return; }
+    link(from, from_is_reverse, to, to_is_reverse);
   }
 }
 
 void
-GFAFile::for_each_path_name(const std::function<bool(const std::string& name)>& path) const
+GFAFile::for_each_path_name(const std::function<void(const std::string& name)>& path) const
 {
   for(const char* iter : this->p_lines)
   {
@@ -583,14 +579,14 @@ GFAFile::for_each_path_name(const std::function<bool(const std::string& name)>& 
     // Path name field.
     field = this->next_field(field);
     std::string path_name = field.str();
-    if(!path(path_name)) { return; }
+    path(path_name);
   }
 }
 
 void
-GFAFile::for_each_path(const std::function<bool(const std::string& name)>& path,
-                       const std::function<bool(const std::string& name, bool is_reverse)>& path_segment,
-                       const std::function<bool()>& finish_path) const
+GFAFile::for_each_path(const std::function<void(const std::string& name)>& path,
+                       const std::function<void(const std::string& name, bool is_reverse)>& path_segment,
+                       const std::function<void()>& finish_path) const
 {
   for(const char* iter : this->p_lines)
   {
@@ -599,23 +595,23 @@ GFAFile::for_each_path(const std::function<bool(const std::string& name)>& path,
 
     // Path name field.
     field = this->next_field(field);
-    if(!path(field.str())) { return; }
+    path(field.str());
 
     // Segment names field.
     do
     {
       field = this->next_subfield(field);
       std::string segment_name = field.path_segment();
-      if(!path_segment(segment_name, field.is_reverse_path_segment())) { return; }
+      path_segment(segment_name, field.is_reverse_path_segment());
     }
     while(field.has_next);
 
-    if(!finish_path()) { return; }
+    finish_path();
   }
 }
 
 void
-GFAFile::for_each_walk_name(const std::function<bool(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk) const
+GFAFile::for_each_walk_name(const std::function<void(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk) const
 {
   for(const char* iter : this->w_lines)
   {
@@ -638,14 +634,14 @@ GFAFile::for_each_walk_name(const std::function<bool(const std::string& sample, 
     field = this->next_field(field);
     std::string start = field.str();
 
-    if(!walk(sample, haplotype, contig, start)) { return; }
+    walk(sample, haplotype, contig, start);
   }
 }
 
 void
-GFAFile::for_each_walk(const std::function<bool(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk,
-                       const std::function<bool(const std::string& name, bool is_reverse)>& walk_segment,
-                       const std::function<bool()>& finish_walk) const
+GFAFile::for_each_walk(const std::function<void(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)>& walk,
+                       const std::function<void(const std::string& name, bool is_reverse)>& walk_segment,
+                       const std::function<void()>& finish_walk) const
 {
   for(const char* iter : this->w_lines)
   {
@@ -668,7 +664,7 @@ GFAFile::for_each_walk(const std::function<bool(const std::string& sample, const
     field = this->next_field(field);
     std::string start = field.str();
 
-    if(!walk(sample, haplotype, contig, start)) { return; }
+    walk(sample, haplotype, contig, start);
 
     // Skip the end field.
     field = this->next_field(field);
@@ -679,24 +675,22 @@ GFAFile::for_each_walk(const std::function<bool(const std::string& sample, const
     {
       field = this->next_walk_subfield(field);
       std::string segment_name = field.walk_segment();
-      if(!walk_segment(segment_name, field.is_reverse_walk_segment())) { return; }
+      walk_segment(segment_name, field.is_reverse_walk_segment());
     }
     while(field.has_next);
 
-    if(!finish_walk()) { return; }
+    finish_walk();
   }
 }
 
 //------------------------------------------------------------------------------
 
-// FIXME exceptions
-bool
+void
 check_gfa_file(const GFAFile& gfa_file, const GFAParsingParameters& parameters)
 {
   if(gfa_file.segments() == 0)
   {
-    std::cerr << "check_gfa_file(): No segments in the GFA file" << std::endl;
-    return false;
+    throw std::runtime_error("No segments in the GFA file");
   }
   if(gfa_file.paths() > 0 && gfa_file.walks() > 0)
   {
@@ -707,11 +701,8 @@ check_gfa_file(const GFAFile& gfa_file, const GFAParsingParameters& parameters)
   }
   if(gfa_file.paths() == 0 && gfa_file.walks() == 0)
   {
-    std::cerr << "check_gfa_file(): No paths or walks in the GFA file" << std::endl;
-    return false;
+    throw std::runtime_error("No paths or walks in the GFA file");
   }
-
-  return true;
 }
 
 gbwt::size_type
@@ -761,7 +752,7 @@ parse_segments(const GFAFile& gfa_file, const GFAParsingParameters& parameters)
   }
 
   std::pair<std::unique_ptr<SequenceSource>, std::unique_ptr<EmptyGraph>> result(new SequenceSource(), new EmptyGraph());
-  gfa_file.for_each_segment([&](const std::string& name, view_type sequence) -> bool
+  gfa_file.for_each_segment([&](const std::string& name, view_type sequence)
   {
     if(translate)
     {
@@ -777,7 +768,6 @@ parse_segments(const GFAFile& gfa_file, const GFAParsingParameters& parameters)
       result.first->add_node(id, sequence);
       result.second->create_node(id);
     }
-    return true;
   });
 
   if(parameters.show_progress)
@@ -788,7 +778,6 @@ parse_segments(const GFAFile& gfa_file, const GFAParsingParameters& parameters)
   return result;
 }
 
-// FIXME exceptions
 void
 parse_links(const GFAFile& gfa_file, const SequenceSource& source, EmptyGraph& graph, const GFAParsingParameters& parameters)
 {
@@ -798,28 +787,25 @@ parse_links(const GFAFile& gfa_file, const SequenceSource& source, EmptyGraph& g
     std::cerr << "Parsing links" << std::endl;
   }
 
-  bool ok = true;
   size_t edge_count = 0;
-  gfa_file.for_each_link([&](const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse) -> bool
+  gfa_file.for_each_link([&](const std::string& from, bool from_is_reverse, const std::string& to, bool to_is_reverse)
   {
     if(source.uses_translation())
     {
       std::pair<nid_t, nid_t> from_nodes = source.get_translation(from);
       if(from_nodes == SequenceSource::invalid_translation())
       {
-        std::cerr << "parse_links(): Invalid segment: " << from << std::endl;
-        ok = false; return false;
+        throw std::runtime_error("Invalid source segement " + from);
       }
       std::pair<nid_t, nid_t> to_nodes = source.get_translation(to);
       if(to_nodes == SequenceSource::invalid_translation())
       {
-        std::cerr << "parse_links(): Invalid segment: " << from << std::endl;
-        ok = false; return false;
+        throw std::runtime_error("Invalid destination segment " + to);
       }
       nid_t from_node = (from_is_reverse ? from_nodes.first : from_nodes.second - 1);
       nid_t to_node = (to_is_reverse ? to_nodes.second - 1 : to_nodes.first);
       graph.create_edge(graph.get_handle(from_node, from_is_reverse), graph.get_handle(to_node, to_is_reverse));
-        edge_count++;
+      edge_count++;
     }
     else
     {
@@ -832,15 +818,10 @@ parse_links(const GFAFile& gfa_file, const SequenceSource& source, EmptyGraph& g
       }
       catch(const std::exception& e)
       {
-        std::cerr << "parse_links(): Invalid node id: " << e.what() << std::endl;
-        ok = false; return false;
+        throw std::runtime_error("Invalid node id: " + std::string(e.what()));
       }
     }
-    return true;
   });
-
-  // FIXME exception
-  if(!ok) { return; }
 
   // Add edges inside segments if necessary.
   if(source.uses_translation())
@@ -865,72 +846,50 @@ parse_links(const GFAFile& gfa_file, const SequenceSource& source, EmptyGraph& g
   }
 }
 
-// FIXME this should return metadata or throw an exception
-bool
-parse_metadata(const GFAFile& gfa_file, const GFAParsingParameters& parameters, MetadataBuilder& metadata, gbwt::GBWTBuilder& builder)
+gbwt::Metadata
+parse_metadata(const GFAFile& gfa_file, MetadataBuilder& metadata, const GFAParsingParameters& parameters)
 {
   double start = gbwt::readTimer();
   if(parameters.show_progress)
   {
     std::cerr << "Parsing metadata" << std::endl;
   }
-  builder.index.addMetadata();
 
   // Parse walks.
   if(gfa_file.walks() > 0)
   {
     // Parse reference paths.
-    bool failed = false;
     if(gfa_file.paths() > 0)
     {
-      gfa_file.for_each_path_name([&](const std::string& name) -> bool
+      gfa_file.for_each_path_name([&](const std::string& name)
       {
-        if(!(metadata.add_reference_path(name))) { failed = true; return false; }
-        return true;
+        metadata.add_reference_path(name);
       });
-      if(failed)
-      {
-        std::cerr << "parse_metadata(): Could not parse GBWT metadata from reference path names" << std::endl;
-        return false;
-      }
     }
     // Parse walks.
-    gfa_file.for_each_walk_name([&](const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start) -> bool
+    gfa_file.for_each_walk_name([&](const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)
     {
-      if(!(metadata.add_walk(sample, haplotype, contig, start))) { failed = true; return false; }
-      return true;
+      metadata.add_walk(sample, haplotype, contig, start);
     });
-    if(failed)
-    {
-      std::cerr << "parse_metadata(): Could not parse GBWT metadata from walks" << std::endl;
-      return false;
-    }
   }
 
   // Parse paths.
   else if(gfa_file.paths() > 0)
   {
-    bool failed = false;
-    gfa_file.for_each_path_name([&](const std::string& name) -> bool
+    gfa_file.for_each_path_name([&](const std::string& name)
     {
-      if(!(metadata.parse(name))) { failed = true; return false; }
-      return true;
+      metadata.parse(name);
     });
-    if(failed)
-    {
-      std::cerr << "parse_metadata(): Could not parse GBWT metadata from path names" << std::endl;
-      return false;
-    }
   }
 
-  builder.index.metadata = metadata.get_metadata();
+  gbwt::Metadata result = metadata.get_metadata();
   if(parameters.show_progress)
   {
     double seconds = gbwt::readTimer() - start;
     std::cerr << "Parsed metadata in " << seconds << " seconds" << std::endl;
-    std::cerr << "Metadata: "; gbwt::operator<<(std::cerr, builder.index.metadata) << std::endl;
+    std::cerr << "Metadata: "; gbwt::operator<<(std::cerr, result) << std::endl;
   }
-  return true;
+  return result;
 }
 
 void
@@ -943,15 +902,14 @@ parse_paths(const GFAFile& gfa_file, const GFAParsingParameters& parameters, con
   }
 
   gbwt::vector_type current_path;
-  auto add_segment = [&](const std::string& name, bool is_reverse) -> bool
+  auto add_segment = [&](const std::string& name, bool is_reverse)
   {
     if(source.uses_translation())
     {
       std::pair<nid_t, nid_t> range = source.get_translation(name);
       if(range.first == 0 && range.second == 0)
       {
-        // FIXME error message?
-        return false;
+        throw std::runtime_error("Invalid path segment " + name);
       }
       if(is_reverse)
       {
@@ -972,27 +930,22 @@ parse_paths(const GFAFile& gfa_file, const GFAParsingParameters& parameters, con
     {
       current_path.push_back(gbwt::Node::encode(stoul_unsafe(name), is_reverse));
     }
-    return true;
   };
 
   // Parse paths.
-  gfa_file.for_each_path([&](const std::string&) -> bool
+  gfa_file.for_each_path([&](const std::string&)
   {
-    return true;
-  }, add_segment, [&]() -> bool
+  }, add_segment, [&]()
   {
     builder.insert(current_path, true); current_path.clear();
-    return true;
   });
 
   // Parse walks
-  gfa_file.for_each_walk([&](const std::string&, const std::string&, const std::string&, const std::string&) -> bool
+  gfa_file.for_each_walk([&](const std::string&, const std::string&, const std::string&, const std::string&)
   {
-    return true;
-  }, add_segment, [&]() -> bool
+  }, add_segment, [&]()
   {
     builder.insert(current_path, true); current_path.clear();
-    return true;
   });
 
   // Finish construction.
@@ -1014,11 +967,7 @@ gfa_to_gbwt(const std::string& gfa_filename, const GFAParsingParameters& paramet
 
   // GFA parsing.
   GFAFile gfa_file(gfa_filename, parameters.show_progress);
-  // FIXME exceptions
-  if(!check_gfa_file(gfa_file, parameters))
-  {
-    return std::make_pair(std::unique_ptr<gbwt::GBWT>(nullptr), std::unique_ptr<SequenceSource>(nullptr));
-  }
+  check_gfa_file(gfa_file, parameters);
 
   // Adjust batch size by GFA size and maximum path length.
   gbwt::size_type batch_size = determine_batch_size(gfa_file, parameters);
@@ -1029,7 +978,6 @@ gfa_to_gbwt(const std::string& gfa_filename, const GFAParsingParameters& paramet
   std::tie(source, graph) = parse_segments(gfa_file, parameters);
 
   // Parse links and create jobs.
-  // FIXME error handling
   parse_links(gfa_file, *source, *graph, parameters);
   // FIXME determine jobs, create node-to-job mapping
   graph.reset(); // We no longer need graph topology.
@@ -1038,11 +986,8 @@ gfa_to_gbwt(const std::string& gfa_filename, const GFAParsingParameters& paramet
   // FIXME we build and merge multiple GBWTs
   gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
   gbwt::GBWTBuilder builder(parameters.node_width, batch_size, parameters.sample_interval);
-  // FIXME use exceptions
-  if(!parse_metadata(gfa_file, parameters, metadata, builder))
-  {
-    return std::make_pair(std::unique_ptr<gbwt::GBWT>(nullptr), std::unique_ptr<SequenceSource>(nullptr));
-  }
+  builder.index.addMetadata();
+  builder.index.metadata = parse_metadata(gfa_file, metadata, parameters);
 
   // Build GBWT from the paths and the walks.
   parse_paths(gfa_file, parameters, *source, builder);

--- a/src/gfa2gbwt.cpp
+++ b/src/gfa2gbwt.cpp
@@ -33,7 +33,7 @@ struct Config
 
 const std::string tool_name = "GFA to GBWTGraph";
 
-void parse_gfa(GBZ& gbz, const Config& config);
+void parse_gfa(GBZ& gbz, const Config& config); // May throw `std::runtime_error`.
 void load_gbz(GBZ& gbz, const Config& config);
 void load_graph(GBZ& gbz, const Config& config);
 
@@ -63,38 +63,46 @@ main(int argc, char** argv)
   GBZ gbz;
   std::unordered_map<std::string, std::pair<nid_t, nid_t>> translation;
 
-  // Handle the input.
-  if(config.input == input_gfa)
+  try
   {
-    parse_gfa(gbz, config);
-  }
-  else if(config.input == input_gbz)
-  {
-    load_gbz(gbz, config);
-  }
-  else if(config.input == input_graph)
-  {
-    load_graph(gbz, config);
-  }
+    // Handle the input.
+    if(config.input == input_gfa)
+    {
+      parse_gfa(gbz, config);
+    }
+    else if(config.input == input_gbz)
+    {
+      load_gbz(gbz, config);
+    }
+    else if(config.input == input_graph)
+    {
+      load_graph(gbz, config);
+    }
 
-  // Handle the output.
-  if(config.output == output_gfa)
-  {
-    write_gfa(gbz, config);
-  }
-  else if(config.output == output_gbz)
-  {
-    write_gbz(gbz, config);
-  }
-  else if(config.output == output_graph)
-  {
-    write_graph(gbz, config);
-  }
+    // Handle the output.
+    if(config.output == output_gfa)
+    {
+      write_gfa(gbz, config);
+    }
+    else if(config.output == output_gbz)
+    {
+      write_gbz(gbz, config);
+    }
+    else if(config.output == output_graph)
+    {
+      write_graph(gbz, config);
+    }
 
-  // Extract the translation.
-  if(config.translation)
+    // Extract the translation.
+    if(config.translation)
+    {
+      extract_translation(gbz, config);
+    }
+  }
+  catch(const std::exception& e)
   {
-    extract_translation(gbz, config);
+    std::cerr << "Error: " << e.what() << std::endl;
+    std::exit(EXIT_FAILURE);
   }
 
   if(config.show_progress)
@@ -258,12 +266,8 @@ parse_gfa(GBZ& gbz, const Config& config)
     std::cerr << "Path name regex: " << config.parameters.path_name_regex << std::endl;
     std::cerr << "Path name fields: " << config.parameters.path_name_fields << std::endl;
   }
+  // This may throw an exception.
   auto result = gfa_to_gbwt(gfa_name, config.parameters);
-  if(result.first.get() == nullptr || result.second.get() == nullptr)
-  {
-    std::cerr << "gfa2gbwt: Construction failed" << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
 
   if(config.show_progress)
   {

--- a/src/gfa2gbwt.cpp
+++ b/src/gfa2gbwt.cpp
@@ -21,6 +21,7 @@ struct Config
   Config(int argc, char** argv);
 
   GFAParsingParameters parameters;
+  GFAExtractionParameters output_parameters;
   std::string basename;
 
   input_type input = input_gfa;
@@ -63,6 +64,10 @@ main(int argc, char** argv)
       gbwt::printHeader("--max-node", std::cerr) << config.parameters.max_node_length << std::endl;
       gbwt::printHeader("--path-regex", std::cerr) << config.parameters.path_name_regex << std::endl;
       gbwt::printHeader("--path-fields", std::cerr) << config.parameters.path_name_fields << std::endl;
+    }
+    if(config.output == output_gfa)
+    {
+      gbwt::printHeader("--parallel-jobs", std::cerr) << config.output_parameters.num_threads << std::endl;
     }
     std::cerr << std::endl;
   }
@@ -148,7 +153,7 @@ printUsage(int exit_code)
   std::cerr << std::endl;
   std::cerr << "Parallel options:" << std::endl;
   std::cerr << "  -j, --approx-jobs N     create approximately N GBWT construction jobs (default " << GFAParsingParameters::APPROXIMATE_NUM_JOBS << ")" << std::endl;
-  std::cerr << "  -P, --parallel-jobs N   run N jobs in parallel (default 1)" << std::endl;
+  std::cerr << "  -P, --parallel-jobs N   run N construction / extraction jobs in parallel (default 1)" << std::endl;
   std::cerr << std::endl;
   std::cerr << "Other options:" << std::endl;
   std::cerr << "  -s, --simple-sds-graph  serialize " << GBWTGraph::EXTENSION << " in simple-sds format instead of libhandlegraph format" << std::endl;
@@ -231,6 +236,7 @@ Config::Config(int argc, char** argv)
     case 'p':
       this->show_progress = true;
       this->parameters.show_progress = true;
+      this->output_parameters.show_progress = true;
       break;
     case 't':
       this->translation = true;
@@ -251,6 +257,7 @@ Config::Config(int argc, char** argv)
         std::cerr << "gfa2gbwt: Invalid number of parallel jobs: " << optarg << std::endl;
         std::exit(EXIT_FAILURE);
       }
+      this->output_parameters.num_threads = this->parameters.parallel_jobs;
       break;
 
     case 's':
@@ -342,7 +349,7 @@ write_gfa(const GBZ& gbz, const Config& config)
   std::ofstream out;
   out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
   out.open(gfa_name, std::ios_base::binary);
-  gbwt_to_gfa(gbz.graph, out, config.show_progress);
+  gbwt_to_gfa(gbz.graph, out, config.output_parameters);
   out.close();
 }
 

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -45,6 +45,24 @@ TSVWriter::flush()
 
 //------------------------------------------------------------------------------
 
+ManualTSVWriter::ManualTSVWriter(std::ostream& out) :
+  out(out)
+{
+  this->buffer.reserve(BUFFER_SIZE);
+}
+
+void
+ManualTSVWriter::flush()
+{
+  if(!(this->buffer.empty()))
+  {
+    this->out.write(this->buffer.data(), this->buffer.size());
+    this->buffer.clear();
+  }
+}
+
+//------------------------------------------------------------------------------
+
 MetadataBuilder::MetadataBuilder(const std::string& path_name_regex, const std::string& path_name_fields) :
   sample_field(NO_FIELD), contig_field(NO_FIELD), haplotype_field(NO_FIELD), fragment_field(NO_FIELD),
   ref_path_sample_warning(false)

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -82,14 +82,14 @@ MetadataBuilder::MetadataBuilder(const std::string& path_name_regex, const std::
       case 'h':
         if(this->haplotype_field != NO_FIELD)
         {
-          throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Duplicate haplotype field");
+          throw std::runtime_error("MetadataBuilder: Duplicate haplotype field");
         }
         this->haplotype_field = i;
         break;
       case 'f':
         if(this->fragment_field != NO_FIELD)
         {
-          throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Duplicate fragment field");
+          throw std::runtime_error("MetadataBuilder: Duplicate fragment field");
         }
         this->fragment_field = i;
         break;
@@ -97,14 +97,13 @@ MetadataBuilder::MetadataBuilder(const std::string& path_name_regex, const std::
   }
 }
 
-bool
+void
 MetadataBuilder::parse(const std::string& name)
 {
   std::smatch fields;
   if(!std::regex_match(name, fields, this->parser))
   {
-    std::cerr << "MetadataBuilder::parse(): Invalid path name " << name << std::endl;
-    return false;
+    throw std::runtime_error("MetadataBuilder: Cannot parse path name " + name);
   }
 
   gbwt::PathName path_name =
@@ -149,8 +148,7 @@ MetadataBuilder::parse(const std::string& name)
     try { path_name.phase = std::stoul(fields[this->haplotype_field]); }
     catch(const std::invalid_argument&)
     {
-      std::cerr << "MetadataBuilder::parse(): Invalid haplotype field " << fields[this->haplotype_field] << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Invalid haplotype field " + fields[this->haplotype_field].str());
     }
   }
   this->haplotypes.insert(std::pair<size_t, size_t>(path_name.sample, path_name.phase));
@@ -160,13 +158,11 @@ MetadataBuilder::parse(const std::string& name)
     try { path_name.count = std::stoul(fields[this->fragment_field]); }
     catch(const std::invalid_argument&)
     {
-      std::cerr << "MetadataBuilder::parse(): Invalid fragment field " << fields[this->fragment_field] << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Invalid fragment field " + fields[this->fragment_field].str());
     }
     if(this->counts.find(path_name) != this->counts.end())
     {
-      std::cerr << "MetadataBuilder::parse(): Duplicate path name " << name << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Duplicate path name " + name);
     }
     this->counts[path_name] = 1;
   }
@@ -178,10 +174,9 @@ MetadataBuilder::parse(const std::string& name)
   }
 
   this->path_names.push_back(path_name);
-  return true;
 }
 
-bool
+void
 MetadataBuilder::add_walk(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start)
 {
   gbwt::PathName path_name =
@@ -224,8 +219,7 @@ MetadataBuilder::add_walk(const std::string& sample, const std::string& haplotyp
     try { path_name.phase = std::stoul(haplotype); }
     catch(const std::invalid_argument&)
     {
-      std::cerr << "MetadataBuilder::add_walk(): Invalid haplotype field " << haplotype << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Invalid haplotype field " + haplotype);
     }
   }
   this->haplotypes.insert(std::pair<size_t, size_t>(path_name.sample, path_name.phase));
@@ -235,22 +229,19 @@ MetadataBuilder::add_walk(const std::string& sample, const std::string& haplotyp
     try { path_name.count = std::stoul(start); }
     catch(const std::invalid_argument&)
     {
-      std::cerr << "MetadataBuilder::add_walk(): Invalid start_position " << start << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Invalid start position " + start);
     }
     if(this->counts.find(path_name) != this->counts.end())
     {
-      std::cerr << "MetadataBuilder::add_walk(): Duplicate walk " << sample << "\t" << haplotype << "\t" << contig << "\t" << start << ")" << std::endl;
-      return false;
+      throw std::runtime_error("MetadataBuilder: Duplicate walk " + sample + "\t" + haplotype + "\t" + contig + "\t" + start);
     }
     this->counts[path_name] = 1;
   }
 
   this->path_names.push_back(path_name);
-  return true;
 }
 
-bool
+void
 MetadataBuilder::add_reference_path(const std::string& name)
 {
   gbwt::PathName path_name =
@@ -288,13 +279,11 @@ MetadataBuilder::add_reference_path(const std::string& name)
 
   if(this->counts.find(path_name) != this->counts.end())
   {
-    std::cerr << "MetadataBuilder::add_reference_path(): Duplicate path " << name << std::endl;
-    return false;
+    throw std::runtime_error("MetadataBuilder: Duplicate reference path " + name);
   }
   this->counts[path_name] = 1;
 
   this->path_names.push_back(path_name);
-  return true;
 }
 
 gbwt::Metadata

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -8,51 +8,6 @@ namespace gbwtgraph
 
 //------------------------------------------------------------------------------
 
-BufferedHashSet::BufferedHashSet()
-{
-}
-
-BufferedHashSet::~BufferedHashSet()
-{
-  // Wait for the insertion thread to finish.
-  if(this->worker.joinable()) { this->worker.join(); }
-}
-
-void
-BufferedHashSet::finish()
-{
-  // Flush the buffer if necessary.
-  this->flush();
-
-  // Wait for the insertion thread to finish.
-  if(this->worker.joinable()) { this->worker.join(); }
-}
-
-void
-insert_keys(std::unordered_set<std::string>& data, std::vector<std::string>& buffer)
-{
-  for(std::string& str : buffer) { data.insert(std::move(str)); }
-}
-
-void
-BufferedHashSet::flush()
-{
-  // Wait for the insertion thread to finish.
-  if(this->worker.joinable()) { this->worker.join(); }
-
-  // Swap the input buffer and the internal buffer.
-  this->internal_buffer.swap(this->input_buffer);
-  this->input_buffer.clear();
-
-  // Launch a new construction thread if necessary.
-  if(this->internal_buffer.size() > 0)
-  {
-    this->worker = std::thread(insert_keys, std::ref(this->data), std::ref(this->internal_buffer));
-  }
-}
-
-//------------------------------------------------------------------------------
-
 TSVWriter::TSVWriter(std::ostream& out) :
   out(out)
 {
@@ -88,6 +43,14 @@ TSVWriter::flush()
 }
 
 //------------------------------------------------------------------------------
+
+void
+GFAGraph::insert_node(nid_t node_id, view_type sequence)
+{
+  this->nodes[node_id] = { sequence, {}, {} };
+  this->min_id = std::min(this->min_id, node_id);
+  this->max_id = std::max(this->max_id, node_id);
+}
 
 bool
 GFAGraph::insert_edge(const handle_t& from, const handle_t& to)

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -89,4 +89,167 @@ TSVWriter::flush()
 
 //------------------------------------------------------------------------------
 
+bool
+GFAGraph::insert_edge(const handle_t& from, const handle_t& to)
+{
+  auto from_iter = this->get_node_mut(from);
+  auto to_iter = this->get_node_mut(to);
+  if(!(from_iter == this->nodes.end() || to_iter == this->nodes.end())) { return false; }
+
+  // from -> to
+  if(this->get_is_reverse(from))
+  {
+    from_iter->second.predecessors.push_back(this->flip(to));
+  }
+  else
+  {
+    from_iter->second.successors.push_back(to);
+  }
+
+  // to -> from
+  if(this->get_is_reverse(to))
+  {
+    to_iter->second.successors.push_back(this->flip(from));
+  }
+  else
+  {
+    to_iter->second.predecessors.push_back(from);
+  }
+
+  return true;
+}
+
+void
+GFAGraph::remove_duplicate_edges()
+{
+  this->for_each_handle([&](const handle_t& handle) {
+    auto iter = this->get_node_mut(handle);
+    gbwt::removeDuplicates(iter->second.predecessors, false);
+    gbwt::removeDuplicates(iter->second.successors, false);
+  });
+}
+
+bool
+GFAGraph::has_node(nid_t node_id) const
+{
+  return (this->nodes.find(node_id) != this->nodes.end());
+}
+
+handle_t
+GFAGraph::get_handle(const nid_t& node_id, bool is_reverse) const
+{
+  return node_to_handle(gbwt::Node::encode(node_id, is_reverse));
+}
+
+nid_t
+GFAGraph::get_id(const handle_t& handle) const
+{
+  return gbwt::Node::id(handle_to_node(handle));
+}
+
+bool
+GFAGraph::get_is_reverse(const handle_t& handle) const
+{
+  return gbwt::Node::is_reverse(handle_to_node(handle));
+}
+
+handle_t
+GFAGraph::flip(const handle_t& handle) const
+{
+  return node_to_handle(gbwt::Node::reverse(handle_to_node(handle)));
+}
+
+size_t
+GFAGraph::get_length(const handle_t& handle) const
+{
+  auto iter = this->get_node(handle);
+  return iter->second.sequence.second;
+}
+
+std::string
+GFAGraph::get_sequence(const handle_t& handle) const
+{
+  auto iter = this->get_node(handle);
+  view_type view = iter->second.sequence;
+  return std::string(view.first, view.second);
+}
+
+char
+GFAGraph::get_base(const handle_t& handle, size_t index) const
+{
+  auto iter = this->get_node(handle);
+  view_type view = iter->second.sequence;
+  return *(view.first + index);
+}
+
+std::string
+GFAGraph::get_subsequence(const handle_t& handle, size_t index, size_t size) const
+{
+  auto iter = this->get_node(handle);
+  view_type view = iter->second.sequence;
+  index = std::min(index, view.second);
+  size = std::min(size, view.second - index);
+  return std::string(view.first + index, view.first + index + size);
+}
+
+size_t
+GFAGraph::get_node_count() const
+{
+  return this->nodes.size();
+}
+
+nid_t
+GFAGraph::min_node_id() const
+{
+  return this->min_id;
+}
+
+nid_t
+GFAGraph::max_node_id() const
+{
+  return this->max_id;
+}
+
+bool
+GFAGraph::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const
+{
+  auto iter = this->get_node(handle);
+  bool flip = this->get_is_reverse(handle);
+  const std::vector<handle_t>& edges = (go_left ^ flip ? iter->second.predecessors : iter->second.successors);
+  for(const handle_t& next : edges)
+  {
+    handle_t actual = (flip ? this->flip(next) : next);
+    if(!iteratee(actual)) { return false; }
+  }
+  return true;
+}
+
+bool
+GFAGraph::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool) const
+{
+  for(auto iter = this->nodes.begin(); iter != this->nodes.end(); ++iter)
+  {
+    if(!iteratee(this->get_handle(iter->first, false))) { return false; }
+  }
+  return true;
+}
+
+size_t
+GFAGraph::get_degree(const handle_t& handle, bool go_left) const
+{
+  auto iter = this->get_node(handle);
+  bool flip = this->get_is_reverse(handle);
+  const std::vector<handle_t>& edges = (go_left ^ flip ? iter->second.predecessors : iter->second.successors);
+  return edges.size();
+}
+
+view_type
+GFAGraph::get_sequence_view(const handle_t& handle) const
+{
+  auto iter = this->get_node(handle);
+  return iter->second.sequence;
+}
+
+//------------------------------------------------------------------------------
+
 } // namespace gbwtgraph

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -53,11 +53,11 @@ MetadataBuilder::MetadataBuilder(const std::string& path_name_regex, const std::
   try { this->parser = std::regex(path_name_regex); }
   catch(std::regex_error& e)
   {
-    throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Invalid regex: " + path_name_regex);
+    throw std::runtime_error("MetadataBuilder: Invalid regex: " + path_name_regex);
   }
   if(path_name_fields.size() > this->parser.mark_count() + 1)
   {
-    throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Field string too long: " + path_name_fields);
+    throw std::runtime_error("MetadataBuilder: Field string too long: " + path_name_fields);
   }
 
   // Initialize the fields.
@@ -68,14 +68,14 @@ MetadataBuilder::MetadataBuilder(const std::string& path_name_regex, const std::
       case 's':
         if(this->sample_field != NO_FIELD)
         {
-          throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Duplicate sample field");
+          throw std::runtime_error("MetadataBuilder: Duplicate sample field");
         }
         this->sample_field = i;
         break;
       case 'c':
         if(this->contig_field != NO_FIELD)
         {
-          throw std::runtime_error("MetadataBuilder::MetadataBuilder(): Duplicate contig field");
+          throw std::runtime_error("MetadataBuilder: Duplicate contig field");
         }
         this->contig_field = i;
         break;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,6 +10,17 @@ namespace gbwtgraph
 
 //------------------------------------------------------------------------------
 
+// Numerical class constants.
+
+constexpr size_t Version::MAJOR_VERSION;
+constexpr size_t Version::MINOR_VERSION;
+constexpr size_t Version::PATCH_VERSION;
+constexpr size_t Version::GBZ_VERSION;
+constexpr size_t Version::GRAPH_VERSION;
+constexpr size_t Version::MINIMIZER_VERSION;
+
+//------------------------------------------------------------------------------
+
 // Global variables.
 
 const std::string REFERENCE_PATH_SAMPLE_NAME = "_gbwt_ref";
@@ -150,6 +161,27 @@ SequenceSource::translate_segment(const std::string& name, view_type sequence, s
   this->segment_translation[name] = translation;
   this->next_id = translation.second;
   return translation;
+}
+
+std::pair<nid_t, nid_t>
+SequenceSource::force_translate(const std::string& segment_name) const
+{
+  if(this->uses_translation())
+  {
+    return this->get_translation(segment_name);
+  }
+  else
+  {
+    try
+    {
+      nid_t id = std::stoul(segment_name);
+      return std::pair<nid_t, nid_t>(id, id + 1);
+    }
+    catch(const std::logic_error&)
+    {
+      return invalid_translation();
+    }
+  }
 }
 
 std::pair<gbwt::StringArray, sdsl::sd_vector<>>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -132,7 +132,7 @@ SequenceSource::add_node(nid_t id, view_type sequence)
 std::pair<nid_t, nid_t>
 SequenceSource::translate_segment(const std::string& name, view_type sequence, size_t max_length)
 {
-  if(sequence.second == 0) { return empty_translation(); }
+  if(sequence.second == 0) { return invalid_translation(); }
   auto iter = this->segment_translation.find(name);
   if(iter != this->segment_translation.end())
   {

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -30,11 +30,23 @@ public:
   void check_translation(const SequenceSource& source, const std::vector<translation_type>& truth) const
   {
     ASSERT_EQ(source.uses_translation(), !(truth.empty())) << "Segment translation is not used as expected";
-    if(!(source.uses_translation())) { return; }
-    ASSERT_EQ(source.segment_translation.size(), truth.size()) << "Invalid number of segments";
-    for(const translation_type& translation : truth)
+    if(source.uses_translation())
     {
-      EXPECT_EQ(source.get_translation(translation.first), translation.second) << "Invalid translation for " << translation.first;
+      ASSERT_EQ(source.segment_translation.size(), truth.size()) << "Invalid number of segments";
+      for(const translation_type& translation : truth)
+      {
+        EXPECT_EQ(source.get_translation(translation.first), translation.second) << "Invalid translation for " << translation.first;
+        EXPECT_EQ(source.force_translate(translation.first), translation.second) << "Invalid forced translation for " << translation.first;
+      }
+    }
+    else
+    {
+      for(auto iter = source.nodes.begin(); iter != source.nodes.end(); ++iter)
+      {
+        std::string segment = std::to_string(iter->first);
+        std::pair<nid_t, nid_t> translation(iter->first, iter->first + 1);
+        EXPECT_EQ(source.force_translate(segment), translation) << "Invalid forced translation for " << segment;
+      }
     }
   }
 


### PR DESCRIPTION
Multithreaded GFA (de)compression in `gfa2gbwt` and with `gfa_to_gbwt()` / `gbwt_to_gfa()`.

### Compression

The compression algorithm first builds an in-memory graph using GFA segments and links. (The links were not used before.) The graph is partitioned into weakly connected components and the components are sorted by minimum node ids. Contiguous ranges of components are combined into jobs:

1. Each job contains at least one component.
2. Multiple components can be combined into the same job if their total size (in nodes) does not exceed `get_node_count() / approximate_num_jobs`. (The latter defaults to 32.)

Jobs are run from the largest to the smallest (by node count), and a separate partial GBWT is built for each job. Multiple jobs can be run in parallel. Memory usage is often lower than in the old algorithm, which built a single GBWT for the entire graph, but it increases with the number of parallel jobs.

Partial GBWTs are merged into the final GBWT using the fast algorithm. The algorithm will fail if multiple GBWTs use same node ids. This can only happen if the GFA is invalid: if the paths/walks use edges not listed as links. The merging order is the original component order, making the construction deterministic.

Path order is different from the old algorithm. In the old algorithm, all P-lines were listed first in the GFA order, followed by all W-lines in the GFA order. In the new algorithm, this is done separately for each job and the paths from each job are listed in the merging order.

Some sanity checks are now done later during GBWT construction for performance reasons.

### Decompression

Multiple threads can be used for extracting paths from the GBWT and writing them into the GFA file. Single-threaded decompression maintains the path order in the GBWT, while multithreaded decompression writes them opportunistically.