### PR TITLE
Allow storing translations for handle graph GBWTGraphs

### DIFF
--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -524,7 +524,7 @@ private:
   // NamedNodeBackTranslation into the internal representation used in a
   // GBWTGraph.
   // Returns `StringArray` of segment names and `sd_vector<>` mapping node ids to names.
-  // Skips nodes that don't exist in the GBWTGraph.
+  // Runs of nonexistent nodes become segments with empty names.
   // Throws if the translation cannot be represented (i.e. segments aren't
   // forward strands of contiguous ascending node ID ranges).
   std::pair<gbwt::StringArray, sdsl::sd_vector<>> 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -51,13 +51,13 @@ public:
   GBWTGraph(GBWTGraph&& source);
   ~GBWTGraph();
 
-  // Build the graph from another `HandleGraph`.
-  GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_source);
+  // Build the graph from another `HandleGraph` and an optional named segment space over it.
+  GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_source, const NamedNodeBackTranslation* segment_space = nullptr);
 
   // Build the graph (and possibly the translation) from a `SequenceSource` object.
   // If the translation is present, some parts of the construction are multithreaded.
   GBWTGraph(const gbwt::GBWT& gbwt_index, const SequenceSource& sequence_source);
-
+  
   void swap(GBWTGraph& another);
   GBWTGraph& operator=(const GBWTGraph& source);
   GBWTGraph& operator=(GBWTGraph&& source);
@@ -523,6 +523,16 @@ private:
 
   // Throws sdsl::simple_sds::InvalidData if the checks fail.
   void sanity_checks();
+
+  // Copies a translation over this graph's node IDs from a
+  // NamedNodeBackTranslation into the internal representation used in a
+  // GBWTGraph.
+  // Returns `StringArray` of segment names and `sd_vector<>` mapping node ids to names.
+  // Skips nodes that don't exist in the GBWTGraph.
+  // Throws if the translation cannot be represented (i.e. segments aren't
+  // forward strands of contiguous ascending node ID ranges).
+  std::pair<gbwt::StringArray, sdsl::sd_vector<>> 
+  copy_translation(const NamedNodeBackTranslation& translation) const;
 
   size_t node_offset(gbwt::node_type node) const { return node - this->index->firstNode(); }
   size_t node_offset(const handle_t& handle) const { return this->node_offset(handle_to_node(handle)); }

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -206,7 +206,13 @@ GBWTGraph::copy_translation(const NamedNodeBackTranslation& translation) const
   nid_t prev_segment_number = std::numeric_limits<nid_t>::max();
   bool prev_node_existed = false;
   size_t next_offset_along_segment = std::numeric_limits<size_t>::max();
-  
+
+  if(this->index->firstNode() > 1)
+  {
+    // Have a segment for the first run of nonexistent nodes
+    segment_names_and_starts.emplace_back("", 1);
+  }
+
   for(gbwt::node_type node = this->index->firstNode(); node < this->index->sigma(); node += 2)
   {
     // Get each node in the graph, in ID order.

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -204,46 +204,60 @@ GBWTGraph::copy_translation(const NamedNodeBackTranslation& translation) const
   
   // We need to track consistency with our contiguous node ID range segment model.
   nid_t prev_segment_number = std::numeric_limits<nid_t>::max();
+  bool prev_node_existed = false;
   size_t next_offset_along_segment = std::numeric_limits<size_t>::max();
   
   for(gbwt::node_type node = this->index->firstNode(); node < this->index->sigma(); node += 2)
   {
-    nid_t node_id = gbwt::Node::id(node);
-    if(!(this->has_node(node_id))) { continue ; }
     // Get each node in the graph, in ID order.
-    
-    // Translate it back to a segment range.
-    size_t node_length = this->sequences.length(this->node_offset(node));
-    oriented_node_range_t range{node_id, false, 0, node_length};
-    auto translated_back = translation.translate_back(range);
-    if(translated_back.size() != 1)
+    nid_t node_id = gbwt::Node::id(node);
+    if(!(this->has_node(node_id)))
     {
-      // This node didn't come from a segment, or spans multiple segments
-      throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " did not come from exactly one segment"); 
+      // This node doesn't exist.
+      if(prev_node_existed)
+      {
+        // We're starting a nonexistent segment.
+        // We need to remember its empty name and start ID.
+        segment_names_and_starts.emplace_back("", node_id);
+        // Remember we were in a nonexistent segment.
+        prev_node_existed = false;
+      }
     }
-    nid_t& segment_number = std::get<0>(translated_back[0]);
-    bool& reverse_on_segment = std::get<1>(translated_back[0]);
-    size_t& offset_along_segment = std::get<2>(translated_back[0]);
-    if(reverse_on_segment)
+    else
     {
-      // We can only deal with nodes on the forward strands of their segments.
-      throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " came from the reverse strand of its segment"); 
+      // Translate it back to a segment range.
+      size_t node_length = this->sequences.length(this->node_offset(node));
+      oriented_node_range_t range{node_id, false, 0, node_length};
+      auto translated_back = translation.translate_back(range);
+      if(translated_back.size() != 1)
+      {
+        // This node didn't come from a segment, or spans multiple segments
+        throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " did not come from exactly one segment");
+      }
+      nid_t& segment_number = std::get<0>(translated_back[0]);
+      bool& reverse_on_segment = std::get<1>(translated_back[0]);
+      size_t& offset_along_segment = std::get<2>(translated_back[0]);
+      if(reverse_on_segment)
+      {
+        // We can only deal with nodes on the forward strands of their segments.
+        throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " came from the reverse strand of its segment");
+      }
+      if(!prev_node_existed || prev_segment_number != segment_number)
+      {
+        // This is a new segment!
+        prev_segment_number = segment_number;
+        prev_node_existed = true;
+        next_offset_along_segment = 0;
+        // We need to remember its name and start ID.
+        segment_names_and_starts.emplace_back(translation.get_back_graph_node_name(segment_number), node_id);
+      }
+      if(offset_along_segment != next_offset_along_segment)
+      {
+        // Actually we're not at the right place in the segment, so we can't store this translation.
+        throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " not at expected position in segment");
+      }
+      next_offset_along_segment += node_length;
     }
-    if(prev_segment_number != segment_number)
-    {
-      // This is a new segment!
-      prev_segment_number = segment_number;
-      next_offset_along_segment = 0;
-      
-      // We need to remember its name and start ID.
-      segment_names_and_starts.emplace_back(translation.get_back_graph_node_name(segment_number), node_id);
-    }
-    if(offset_along_segment != next_offset_along_segment)
-    {
-      // Actually we're not at the right place in the segment, so we can't store this translation.
-      throw InvalidGBWT("GBWTGraph: Node " + std::to_string(node_id) + " not at expected position in segment"); 
-    }
-    next_offset_along_segment += node_length;
   }
 
   // Store the segment names.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -153,6 +153,7 @@ SequenceSource::invert_translation(const std::function<bool(std::pair<nid_t, nid
   std::pair<gbwt::StringArray, sdsl::sd_vector<>> result;
 
   // Invert the translation.
+  // This stores semiopen ranges of node identifiers corresponding to segments, and views to their segment names. 
   std::vector<std::pair<std::pair<nid_t, nid_t>, view_type>> inverse;
   inverse.reserve(this->segment_translation.size());
   for(auto iter = this->segment_translation.begin(); iter != this->segment_translation.end(); ++iter)
@@ -166,11 +167,13 @@ SequenceSource::invert_translation(const std::function<bool(std::pair<nid_t, nid
   result.first = gbwt::StringArray(inverse.size(),
   [&](size_t offset) -> size_t
   {
+    // This produces the length of each string to store
     if(is_present(inverse[offset].first)) { return inverse[offset].second.second; }
     else { return 0; }
   },
   [&](size_t offset) -> view_type
   {
+    // This produces a view to each string to store.
     if(is_present(inverse[offset].first)) { return inverse[offset].second; }
     else { return str_to_view(empty); }
   });


### PR DESCRIPTION
This allows a `GBWTGraph` to be created while copying an existing `NamedNodeBackTranslation`. This is necessary for vg when we make `GBWTGraph`s from graphs that we have previously chopped in vg, but which correspond to GFAs. This happens in the indexing pathway for GFAs that don't have their own walks and need a path cover.