### PR TITLE
Cache GBWT records

### DIFF
--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -93,7 +93,9 @@ struct GFAExtractionParameters
     1. Links and paths have no overlaps between segments.
     2. There are no containments.
 
-  If the construction fails, the function throws `std::runtime_error`.
+  If the construction fails, the function throws `std::runtime_error`. However,
+  if there is an error during the multithreaded path/walk parsing stage,
+  the construction exits with `std::exit()`.
 
   Before GBWT construction, the graph is partitioned into weakly connected
   components. The components are ordered by node ids, and contiguous ranges of

--- a/include/gbwtgraph/gfa.h
+++ b/include/gbwtgraph/gfa.h
@@ -78,6 +78,10 @@ struct GFAExtractionParameters
   size_t num_threads = 1;
   size_t threads() const { return std::max(this->num_threads, size_t(1)); }
 
+  // Cache GBWT records larger than this size to speed up decompression.
+  constexpr static size_t LARGE_RECORD_BYTES = 1024;
+  size_t large_record_bytes = LARGE_RECORD_BYTES;
+
   bool show_progress = false;
 };
 

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -1,6 +1,7 @@
 #ifndef GBWTGRAPH_INTERNAL_H
 #define GBWTGRAPH_INTERNAL_H
 
+#include <gbwt/gbwt.h>
 #include <gbwt/metadata.h>
 #include <gbwtgraph/utils.h>
 
@@ -273,6 +274,25 @@ public:
 
   // Convert handle_t to gbwt::node_type.
   static gbwt::node_type handle_to_node(const handle_t& handle) { return handlegraph::as_integer(handle); }
+};
+
+//------------------------------------------------------------------------------
+
+/*
+  A cache that stores GBWT records larger than `bytes` bytes as `DecompressedRecord`
+  and supports faster path extraction from the index.
+*/
+struct LargeRecordCache
+{
+  LargeRecordCache(const gbwt::GBWT& index, size_t bytes);
+
+  size_t size() const { return this->cache.size(); }
+  gbwt::size_type sequences() const { return this->index.sequences(); }
+
+  gbwt::vector_type extract(gbwt::size_type sequence) const;
+
+  const gbwt::GBWT& index;
+  std::unordered_map<gbwt::node_type, gbwt::DecompressedRecord> cache;
 };
 
 //------------------------------------------------------------------------------

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -488,7 +488,7 @@ LargeRecordCache::LargeRecordCache(const gbwt::GBWT& index, size_t bytes) :
   for(gbwt::node_type node = this->index.firstNode(); node < this->index.sigma(); node++)
   {
     std::pair<gbwt::size_type, gbwt::size_type> range = this->index.bwt.getRange(this->index.toComp(node));
-    if(range.second - range.first > bytes)
+    if(range.second - range.first > bytes && !(this->index.empty(node)))
     {
       this->cache[node] = gbwt::DecompressedRecord(this->index.record(node));
     }


### PR DESCRIPTION
Cache large GBWT records for faster GFA decompression. By default, records larger than 1024 bytes are cached as `gbwt::DecompressedRecord`. This speeds up decompressing chr16 of the PGGB human graph from 95 minutes to a bit over 6 minutes while using a few gigabytes more memory during decompression.