### PR TITLE
Keep gbwt paths when subsampling

### DIFF
--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -51,13 +51,13 @@ public:
   GBWTGraph(GBWTGraph&& source);
   ~GBWTGraph();
 
-  // Build the graph from another `HandleGraph`.
-  GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_source);
+  // Build the graph from another `HandleGraph` and an optional named segment space over it.
+  GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& sequence_source, const NamedNodeBackTranslation* segment_space = nullptr);
 
   // Build the graph (and possibly the translation) from a `SequenceSource` object.
   // If the translation is present, some parts of the construction are multithreaded.
   GBWTGraph(const gbwt::GBWT& gbwt_index, const SequenceSource& sequence_source);
-
+  
   void swap(GBWTGraph& another);
   GBWTGraph& operator=(const GBWTGraph& source);
   GBWTGraph& operator=(GBWTGraph&& source);
@@ -523,6 +523,16 @@ private:
 
   // Throws sdsl::simple_sds::InvalidData if the checks fail.
   void sanity_checks();
+
+  // Copies a translation over this graph's node IDs from a
+  // NamedNodeBackTranslation into the internal representation used in a
+  // GBWTGraph.
+  // Returns `StringArray` of segment names and `sd_vector<>` mapping node ids to names.
+  // Skips nodes that don't exist in the GBWTGraph.
+  // Throws if the translation cannot be represented (i.e. segments aren't
+  // forward strands of contiguous ascending node ID ranges).
+  std::pair<gbwt::StringArray, sdsl::sd_vector<>> 
+  copy_translation(const NamedNodeBackTranslation& translation) const;
 
   size_t node_offset(gbwt::node_type node) const { return node - this->index->firstNode(); }
   size_t node_offset(const handle_t& handle) const { return this->node_offset(handle_to_node(handle)); }

--- a/include/gbwtgraph/path_cover.h
+++ b/include/gbwtgraph/path_cover.h
@@ -22,6 +22,19 @@ constexpr size_t PATH_COVER_MIN_K           = 2;
 //------------------------------------------------------------------------------
 
 /*
+  Store the named paths from the given graph into the given GBWT builder, under
+  the special REFERENCE_PATH_SAMPLE_NAME sample. Creates new contigs with the
+  appropriate names, or re-uses any found in the metadata.
+  
+  Skips empty paths.
+  
+  If the given filter function is set, and returns false for a path, that path
+  is not added.
+*/
+void
+store_named_paths(gbwt::GBWTBuilder& builder, const PathHandleGraph& graph, std::function<bool(const path_handle_t&)>* path_filter = nullptr);
+
+/*
   Find a path cover of the graph with n paths per component and return a GBWT of the paths.
   The path cover is built greedily. Each time we extend a path, we choose the extension
   where the coverage of the k >= 2 node window is the lowest. Note that this is a maximum

--- a/include/gbwtgraph/path_cover.h
+++ b/include/gbwtgraph/path_cover.h
@@ -63,11 +63,15 @@ store_named_paths(gbwt::GBWTBuilder& builder, const PathHandleGraph& graph, std:
 
     - When determining window coverage, we consider the window equivalent to its reverse
       complement.
+
+  If include_named_paths is set, named paths from the graph will be stored, if
+  it is a PathHandleGraph.
 */
 gbwt::GBWT path_cover_gbwt(const HandleGraph& graph,
                            size_t n = PATH_COVER_DEFAULT_N, size_t k = PATH_COVER_DEFAULT_K,
                            gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
                            gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
+                           bool include_named_paths = false,
                            bool show_progress = false);
 
 //------------------------------------------------------------------------------
@@ -81,12 +85,16 @@ gbwt::GBWT path_cover_gbwt(const HandleGraph& graph,
 
   In graph components without haplotypes in the GBWT index, this algorithm will revert to
   the regular path cover algorithm.
+  
+  If include_named_paths is set, named paths from the graph will be stored, if
+  it is a PathHandleGraph.
 */
 
 gbwt::GBWT local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index,
                             size_t n = LOCAL_HAPLOTYPES_DEFAULT_N, size_t k = PATH_COVER_DEFAULT_K,
                             gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
                             gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
+                            bool include_named_paths = false,
                             bool show_progress = false);
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/path_cover.h
+++ b/include/gbwtgraph/path_cover.h
@@ -32,7 +32,7 @@ constexpr size_t PATH_COVER_MIN_K           = 2;
   is not added.
 */
 void
-store_named_paths(gbwt::GBWTBuilder& builder, const PathHandleGraph& graph, std::function<bool(const path_handle_t&)>* path_filter = nullptr);
+store_named_paths(gbwt::GBWTBuilder& builder, const PathHandleGraph& graph, const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
 
 /*
   Find a path cover of the graph with n paths per component and return a GBWT of the paths.
@@ -65,13 +65,15 @@ store_named_paths(gbwt::GBWTBuilder& builder, const PathHandleGraph& graph, std:
       complement.
 
   If include_named_paths is set, named paths from the graph will be stored, if
-  it is a PathHandleGraph.
+  it is a PathHandleGraph. If a path_filter is supplied, only paths matching it
+  will be stored.
 */
 gbwt::GBWT path_cover_gbwt(const HandleGraph& graph,
                            size_t n = PATH_COVER_DEFAULT_N, size_t k = PATH_COVER_DEFAULT_K,
                            gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
                            gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
                            bool include_named_paths = false,
+                           const std::function<bool(const path_handle_t&)>* path_filter = nullptr,
                            bool show_progress = false);
 
 //------------------------------------------------------------------------------
@@ -87,7 +89,8 @@ gbwt::GBWT path_cover_gbwt(const HandleGraph& graph,
   the regular path cover algorithm.
   
   If include_named_paths is set, named paths from the graph will be stored, if
-  it is a PathHandleGraph.
+  it is a PathHandleGraph. If a path_filter is supplied, only paths matching it
+  will be stored.
 */
 
 gbwt::GBWT local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index,
@@ -95,6 +98,7 @@ gbwt::GBWT local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index,
                             gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
                             gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
                             bool include_named_paths = false,
+                            const std::function<bool(const path_handle_t&)>* path_filter = nullptr,
                             bool show_progress = false);
 
 //------------------------------------------------------------------------------

--- a/src/path_cover.cpp
+++ b/src/path_cover.cpp
@@ -457,7 +457,7 @@ component_path_cover(const typename Coverage::graph_t& graph, gbwt::GBWTBuilder&
 }
 
 void
-finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, const std::vector<std::string>& contig_names, bool show_progress)
+finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, const std::vector<std::string>& contig_names, size_t haplotypes, bool show_progress)
 {
   builder.finish();
   
@@ -483,8 +483,8 @@ finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, const std::vector<std::s
     builder.index.metadata.setContigs(builder.index.metadata.contigs() + contig_names.size());
   }
   
-  // Record the additional stored haplotypes (one per sample)
-  builder.index.metadata.setHaplotypes(builder.index.metadata.haplotypes() + n);
+  // Record the additional stored haplotypes
+  builder.index.metadata.setHaplotypes(builder.index.metadata.haplotypes() + haplotypes);
   
   if(show_progress)
   {
@@ -493,7 +493,7 @@ finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, const std::vector<std::s
 }
 
 void
-finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, size_t contigs, bool show_progress)
+finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, size_t contigs, size_t haplotypes, bool show_progress)
 {
   std::vector<std::string> contig_names(contigs);
   if(builder.index.metadata.hasContigNames())
@@ -501,7 +501,7 @@ finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, size_t contigs, bool sho
     // Need to fill in contig names
     for(size_t i = 0; i < contigs; i++) { contig_names[i] = ("path_cover_contig_" + std::to_string(i)); }
   }
-  finish_path_cover(builder, n, contig_names, show_progress);
+  finish_path_cover(builder, n, contig_names, haplotypes, show_progress);
 }
 
 /*
@@ -709,7 +709,7 @@ path_cover_gbwt(const HandleGraph& graph,
   }
 
   // Finish the construction, add basic metadata, and return the GBWT.
-  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), show_progress);
+  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), n, show_progress);
   return gbwt::GBWT(builder.index);
 }
 
@@ -799,7 +799,7 @@ local_haplotypes(const HandleGraph& graph,
   }
 
   // Finish the construction, add basic metadata, and return the GBWT.
-  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), show_progress);
+  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), n, show_progress);
   return gbwt::GBWT(builder.index);
 }
 
@@ -853,7 +853,7 @@ augment_gbwt(const HandleGraph& graph,
   if(!contig_names.empty())
   {
     // Finish the construction, augment metadata, and return the number of augmented components.
-    finish_path_cover(builder, n, contig_names, show_progress);
+    finish_path_cover(builder, n, contig_names, 0, show_progress);
   }
   builder.swapIndex(index);
   return contig_names.size();

--- a/src/path_cover.cpp
+++ b/src/path_cover.cpp
@@ -504,6 +504,50 @@ finish_path_cover(gbwt::GBWTBuilder& builder, size_t n, size_t contigs, bool sho
   finish_path_cover(builder, n, contig_names, show_progress);
 }
 
+/// Get a contig number that each component touches, or std::numeric_limits<size_t>::max() if it doesn't touch anything.
+std::vector<size_t>
+find_contigs_for_components(const PathHandleGraph* path_graph, const gbwt::GBWTBuilder& builder, const std::vector<std::vector<nid_t>>& components)
+{
+  // Each component is going to get a contig number. If a component shares a
+  // node with a path, we need it to use the same contig number as that path.
+  std::vector<size_t> component_contigs;
+  
+  for(auto& component : components)
+  {
+    // What contig if any did we find for this component
+    size_t component_contig = std::numeric_limits<size_t>::max();
+    for(auto& node_id : component) {
+      // Look at every node in the component
+      bool finished = path_graph->for_each_step_on_handle(path_graph->get_handle(node_id), [&](const step_handle_t& step) {
+        // And then each step on a path on the node
+        path_handle_t path = path_graph->get_path_handle_of_step(step);
+        std::string path_name = path_graph->get_path_name(path);
+        // And see if we have a contig for the path already
+        size_t path_contig = builder.index.metadata.contig(path_name);
+        if(path_contig != builder.index.metadata.contigs())
+        {
+          // Component touches a node that touches this path that is a contig already.
+          // Component belongs on this contig.
+          component_contig = path_contig;
+          // Stop scanning the component
+          return false;
+        }
+        // Otherwise continue scanning the component
+        return true;
+      });
+      if(!finished)
+      {
+        // We're done early!
+        break;
+      }
+    }
+    
+    // Save what we found, or that we found nothing.
+    component_contigs.push_back(component_contig);
+  }
+  
+  return component_contigs;
+}
 
 
 //------------------------------------------------------------------------------
@@ -610,6 +654,10 @@ path_cover_gbwt(const HandleGraph& graph, size_t n, size_t k, gbwt::size_type ba
   gbwt::GBWTBuilder builder(node_width, batch_size, sample_interval);
   builder.index.addMetadata();
   
+  // Each component is going to get a contig number. If a component shares a
+  // node with a path, we need it to use the same contig number as that path.
+  // If this is empty, we just assign fresh contigs to everything.
+  std::vector<size_t> component_contigs;
   if(include_named_paths)
   {
     const PathHandleGraph* path_graph = dynamic_cast<const PathHandleGraph*>(&graph);
@@ -617,23 +665,32 @@ path_cover_gbwt(const HandleGraph& graph, size_t n, size_t k, gbwt::size_type ba
     {
       // Copy over all named paths
       store_named_paths(builder, *path_graph);
+      
+      // Find the right contigs for all the components, by path name
+      component_contigs = find_contigs_for_components(path_graph, builder, components);
     }
   }
-
+ 
   // Handle each component separately.
   size_t base_sample = builder.index.metadata.samples();
-  size_t base_contig = builder.index.metadata.contigs();
-  size_t processed_components = 0;
-  for(size_t contig = 0; contig < components.size(); contig++)
+  size_t next_contig = builder.index.metadata.contigs();
+  for(size_t component = 0; component < components.size(); component++)
   {
-    if(component_path_cover<SimpleCoverage>(graph, builder, components, contig, n, k, show_progress, base_sample, base_contig + contig))
+    // Decide what contig this component belongs to
+    size_t assigned_contig = component_contigs.empty() ? std::numeric_limits<size_t>::max() : component_contigs[component];
+    size_t contig = assigned_contig == std::numeric_limits<size_t>::max() ? next_contig : assigned_contig;
+    if(component_path_cover<SimpleCoverage>(graph, builder, components, component, n, k, show_progress, base_sample, contig))
     {
-      processed_components++;
+      if(assigned_contig == std::numeric_limits<size_t>::max())
+      {
+        // We used a new contig slot
+        next_contig++;
+      }
     }
   }
 
   // Finish the construction, add basic metadata, and return the GBWT.
-  finish_path_cover(builder, n, processed_components, show_progress);
+  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), show_progress);
   return gbwt::GBWT(builder.index);
 }
 
@@ -677,6 +734,10 @@ local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index, size_t n, si
     gbwt_graph = &created_gbwt_graph;
   }
   
+  // Each component is going to get a contig number. If a component shares a
+  // node with a path, we need it to use the same contig number as that path.
+  // If this is empty, we just assign fresh contigs to everything.
+  std::vector<size_t> component_contigs;
   if(include_named_paths)
   {
     const PathHandleGraph* path_graph = dynamic_cast<const PathHandleGraph*>(&graph);
@@ -684,28 +745,34 @@ local_haplotypes(const HandleGraph& graph, const gbwt::GBWT& index, size_t n, si
     {
       // Copy over all named paths
       store_named_paths(builder, *path_graph);
+      
+      // Find the right contigs for all the components, by path name
+      component_contigs = find_contigs_for_components(path_graph, builder, components);
     }
   }
 
   // Handle each component separately.
   size_t base_sample = builder.index.metadata.samples();
-  size_t base_contig = builder.index.metadata.contigs();
-  size_t processed_components = 0;
-  for(size_t contig = 0; contig < components.size(); contig++)
+  size_t next_contig = builder.index.metadata.contigs();
+  for(size_t component = 0; component < components.size(); component++)
   {
+    // Decide what contig this component belongs to
+    size_t assigned_contig = component_contigs.empty() ? std::numeric_limits<size_t>::max() : component_contigs[component];
+    size_t contig = assigned_contig == std::numeric_limits<size_t>::max() ? next_contig : assigned_contig;
     // Revert to regular path cover if we cannot sample local haplotypes.
-    if(!component_path_cover<LocalHaplotypes>(*gbwt_graph, builder, components, contig, n, k, show_progress, base_sample, base_contig + contig))
+    if(component_path_cover<LocalHaplotypes>(*gbwt_graph, builder, components, component, n, k, show_progress, base_sample, contig) ||
+       component_path_cover<SimpleCoverage>(graph, builder, components, component, n, k, show_progress, base_sample, contig))
     {
-      if(component_path_cover<SimpleCoverage>(graph, builder, components, contig, n, k, show_progress, base_sample, base_contig + contig))
+      if(assigned_contig == std::numeric_limits<size_t>::max())
       {
-        processed_components++;
+        // We used a new contig slot
+        next_contig++;
       }
     }
-    else { processed_components++; }
   }
 
   // Finish the construction, add basic metadata, and return the GBWT.
-  finish_path_cover(builder, n, processed_components, show_progress);
+  finish_path_cover(builder, n, next_contig - builder.index.metadata.contigs(), show_progress);
   return gbwt::GBWT(builder.index);
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -153,6 +153,7 @@ SequenceSource::invert_translation(const std::function<bool(std::pair<nid_t, nid
   std::pair<gbwt::StringArray, sdsl::sd_vector<>> result;
 
   // Invert the translation.
+  // This stores semiopen ranges of node identifiers corresponding to segments, and views to their segment names. 
   std::vector<std::pair<std::pair<nid_t, nid_t>, view_type>> inverse;
   inverse.reserve(this->segment_translation.size());
   for(auto iter = this->segment_translation.begin(); iter != this->segment_translation.end(); ++iter)
@@ -166,11 +167,13 @@ SequenceSource::invert_translation(const std::function<bool(std::pair<nid_t, nid
   result.first = gbwt::StringArray(inverse.size(),
   [&](size_t offset) -> size_t
   {
+    // This produces the length of each string to store
     if(is_present(inverse[offset].first)) { return inverse[offset].second.second; }
     else { return 0; }
   },
   [&](size_t offset) -> view_type
   {
+    // This produces a view to each string to store.
     if(is_present(inverse[offset].first)) { return inverse[offset].second; }
     else { return str_to_view(empty); }
   });


### PR DESCRIPTION
This allows us to keep (or, really, re-store) a configurable subset of paths when making path covers, if the graph used to make the path covers contains paths.

It's on top of #21 right now since vg is using that, but there are still changes we wanted to make to #21.