### PR TITLE
Support updated libhandlegraph PathMetadata API

### DIFF
--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -297,7 +297,7 @@ protected:
 public:
 
     /// What is the given path meant to be representing?
-    virtual Sense get_sense(const path_handle_t& handle) const;
+    virtual PathSense get_sense(const path_handle_t& handle) const;
     
     /// Get the name of the sample or assembly asociated with the
     /// path-or-thread, or NO_SAMPLE_NAME if it does not belong to one.
@@ -309,12 +309,12 @@ public:
     
     /// Get the haplotype number (0 or 1, for diploid) of the path-or-thread,
     /// or NO_HAPLOTYPE if it does not belong to one.
-    virtual int64_t get_haplotype(const path_handle_t& handle) const;
+    virtual size_t get_haplotype(const path_handle_t& handle) const;
     
     /// Get the phase block number (contiguously phased region of a sample,
     /// contig, and haplotype) of the path-or-thread, or NO_PHASE_BLOCK if it
     /// does not belong to one.
-    virtual int64_t get_phase_block(const path_handle_t& handle) const;
+    virtual size_t get_phase_block(const path_handle_t& handle) const;
     
     /// Get the bounds of the path-or-thread that are actually represented
     /// here. Should be NO_SUBRANGE if the entirety is represented here, and
@@ -323,21 +323,21 @@ public:
     ///
     /// If no end position is stored, NO_END_POSITION may be returned for the
     /// end position.
-    virtual std::pair<int64_t, int64_t> get_subrange(const path_handle_t& handle) const;
+    virtual subrange_t get_subrange(const path_handle_t& handle) const;
     
 protected:
     
     /// Loop through all the paths matching the given query. Query elements
     /// which are null match everything. Returns false and stops if the
     /// iteratee returns false.
-    virtual bool for_each_path_matching_impl(const std::unordered_set<PathMetadata::Sense>* senses,
+    virtual bool for_each_path_matching_impl(const std::unordered_set<PathSense>* senses,
                                              const std::unordered_set<std::string>* samples,
                                              const std::unordered_set<std::string>* loci,
                                              const std::function<bool(const path_handle_t&)>& iteratee) const;
     
     /// Loop through all steps on the given handle for paths with the given
     /// sense. Returns false and stops if the iteratee returns false.
-    virtual bool for_each_step_of_sense_impl(const handle_t& visited, const Sense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
+    virtual bool for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
     
 private:
     

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -32,10 +32,12 @@ namespace gbwtgraph
 // Import type definitions from libhandlegraph.
 
 using nid_t = handlegraph::nid_t;
-using off_t = handlegraph::off_t;
+using offset_t = handlegraph::offset_t;
+using subrange_t = handlegraph::subrange_t;
 using pos_t = handlegraph::pos_t;
 using handle_t = handlegraph::handle_t;
 using path_handle_t = handlegraph::path_handle_t;
+using PathSense = handlegraph::PathSense;
 using step_handle_t = handlegraph::step_handle_t;
 using edge_t = handlegraph::edge_t;
 using oriented_node_range_t = handlegraph::oriented_node_range_t;
@@ -109,7 +111,7 @@ struct Version
 // Functions for pos_t manipulation.
 
 inline pos_t
-make_pos_t(nid_t id, bool is_rev, off_t off)
+make_pos_t(nid_t id, bool is_rev, offset_t off)
 {
   return std::make_tuple(id, is_rev, off);
 }
@@ -126,7 +128,7 @@ is_rev(const pos_t& pos)
   return std::get<1>(pos);
 }
 
-inline off_t
+inline offset_t
 offset(const pos_t& pos)
 {
   return std::get<2>(pos);
@@ -144,7 +146,7 @@ get_is_rev(pos_t& pos)
   return std::get<1>(pos);
 }
 
-inline off_t&
+inline offset_t&
 get_offset(pos_t& pos)
 {
   return std::get<2>(pos);

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -40,9 +40,9 @@ public:
   std::map<std::string, gbwt::vector_type> correct_haplotype_paths;
   std::map<std::string, std::string> correct_sample_name;
   std::map<std::string, std::string> correct_locus_name;
-  std::map<std::string, int64_t> correct_haplotype_number;
-  std::map<std::string, int64_t> correct_phase_block_number;
-  std::map<std::string, std::pair<int64_t, int64_t>> correct_subrange;
+  std::map<std::string, size_t> correct_haplotype_number;
+  std::map<std::string, size_t> correct_phase_block_number;
+  std::map<std::string, handlegraph::subrange_t> correct_subrange;
 
   GraphOperations()
   {
@@ -317,7 +317,7 @@ TEST_F(GraphOperations, PathMetadata)
   
   // Make sure iteration of haplotype paths works.
   std::set<std::string> haplotype_paths_seen;
-  this->graph.for_each_path_of_sense(handlegraph::PathMetadata::SENSE_HAPLOTYPE, [&](const handlegraph::path_handle_t& path_handle)
+  this->graph.for_each_path_of_sense(handlegraph::PathSense::HAPLOTYPE, [&](const handlegraph::path_handle_t& path_handle)
   {
     auto name = this->graph.get_path_name(path_handle);
     haplotype_paths_seen.insert(name);
@@ -328,7 +328,7 @@ TEST_F(GraphOperations, PathMetadata)
     
   // Make sure iteration of reference paths works (even if we can't store any).
   std::set<std::string> reference_paths_seen;
-  this->graph.for_each_path_of_sense(handlegraph::PathMetadata::SENSE_REFERENCE, [&](const handlegraph::path_handle_t& path_handle)
+  this->graph.for_each_path_of_sense(handlegraph::PathSense::REFERENCE, [&](const handlegraph::path_handle_t& path_handle)
   {
     auto name = this->graph.get_path_name(path_handle);
     reference_paths_seen.insert(name);
@@ -339,7 +339,7 @@ TEST_F(GraphOperations, PathMetadata)
     
   // Make sure iteration of generic paths works.
   std::set<std::string> generic_paths_seen;
-  this->graph.for_each_path_of_sense(handlegraph::PathMetadata::SENSE_GENERIC, [&](const handlegraph::path_handle_t& path_handle)
+  this->graph.for_each_path_of_sense(handlegraph::PathSense::GENERIC, [&](const handlegraph::path_handle_t& path_handle)
   {
     auto name = this->graph.get_path_name(path_handle);
     generic_paths_seen.insert(name);
@@ -375,7 +375,7 @@ TEST_F(GraphOperations, PathMetadata)
     
     // Make sure we can see steps
     bool found_front_step = false;
-    this->graph.for_each_step_of_sense(front_visit, handlegraph::PathMetadata::SENSE_HAPLOTYPE, [&](const handlegraph::step_handle_t& step)
+    this->graph.for_each_step_of_sense(front_visit, handlegraph::PathSense::HAPLOTYPE, [&](const handlegraph::step_handle_t& step)
     {
       if(step == front_handle)
       {
@@ -386,7 +386,7 @@ TEST_F(GraphOperations, PathMetadata)
     });
     EXPECT_TRUE(found_front_step) << "Front step of " << kv.first << " not visible on node";
     bool found_back_step = false;
-    this->graph.for_each_step_of_sense(back_visit, handlegraph::PathMetadata::SENSE_HAPLOTYPE, [&](const handlegraph::step_handle_t& step)
+    this->graph.for_each_step_of_sense(back_visit, handlegraph::PathSense::HAPLOTYPE, [&](const handlegraph::step_handle_t& step)
     {
       if(step == back_handle)
       {
@@ -402,7 +402,7 @@ TEST_F(GraphOperations, PathMetadata)
       << "Path " << kv.first << " appears to have the wrong number of steps";
       
     // Check sense
-    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathMetadata::SENSE_HAPLOTYPE)
+    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathSense::HAPLOTYPE)
       << "Haplotype has wrong sense";
   }
   
@@ -410,7 +410,7 @@ TEST_F(GraphOperations, PathMetadata)
   {
     handlegraph::path_handle_t path_handle = this->graph.get_path_handle(kv.first);
     // Check sense of reference paths
-    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathMetadata::SENSE_REFERENCE)
+    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathSense::REFERENCE)
       << "Named path has wrong sense";
   }
   
@@ -418,7 +418,7 @@ TEST_F(GraphOperations, PathMetadata)
   {
     handlegraph::path_handle_t path_handle = this->graph.get_path_handle(kv.first);
     // Check sense of generic named paths
-    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathMetadata::SENSE_GENERIC)
+    EXPECT_EQ(this->graph.get_sense(path_handle), handlegraph::PathSense::GENERIC)
       << "Named path has wrong sense";
   }
   


### PR DESCRIPTION
I refactored libhandlegraph in https://github.com/vgteam/libhandlegraph/pull/84. This is what gbwtgraph needs in order to build and pass its tests on top of the updated libhandlegraph, without the reference-sense path implementation of #26.