### PR TITLE
Weighted minimizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ HEADERS=$(wildcard include/gbwtgraph/*.h)
 LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o internal.o minimizer.o path_cover.o utils.o)
 LIBRARY=$(BUILD_LIB)/libgbwtgraph.a
 
-PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt gbz_stats)
+PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt gbz_stats kmer_freq)
 OBSOLETE=gfa2gbwt
 
 .PHONY: all clean directories test

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The package also includes:
 
 * [GBZ file format](https://github.com/jltsiren/gbwtgraph/blob/master/SERIALIZATION.md).
 * GBWT / GBWTGraph construction from a subset of GFA1, and GFA extraction from a GBWTGraph.
-* A minimizer index implementation for indexing the haplotypes in the GBWTGraph.
+* A generic kmer index and a generic minimizer index for indexing the haplotypes in the GBWTGraph.
 * GBWT construction from a greedy maximum path cover:
   * Artificial paths that try to cover all length-k contexts equally, either in the entire graph or only in components that do not already contain paths.
   * Concatenations of local length-k haplotypes sampled according to their true frequencies.

--- a/include/gbwtgraph/index.h
+++ b/include/gbwtgraph/index.h
@@ -27,7 +27,7 @@ namespace gbwtgraph
 template<class KeyType>
 void
 index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType>& index,
-                 const std::function<payload_type(const pos_t&)>& get_payload)
+                 const std::function<Payload(const pos_t&)>& get_payload)
 {
   typedef typename MinimizerIndex<KeyType>::minimizer_type minimizer_type;
 
@@ -40,7 +40,7 @@ index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType>& index,
   {
     std::vector<std::pair<minimizer_type, pos_t>>& current_cache = cache[thread_id];
     gbwt::removeDuplicates(current_cache, false);
-    std::vector<payload_type> payload;
+    std::vector<Payload> payload;
     payload.reserve(current_cache.size());
     for(size_t i = 0; i < current_cache.size(); i++) { payload.push_back(get_payload(current_cache[i].second)); }
     #pragma omp critical (minimizer_index)

--- a/include/gbwtgraph/index.h
+++ b/include/gbwtgraph/index.h
@@ -18,6 +18,9 @@ namespace gbwtgraph
 
 //------------------------------------------------------------------------------
 
+// TODO: These three algorithms are basically the same. Is there a clean way of
+// merging the implementations?
+
 /*
   Index the haplotypes in the graph. Insert the minimizers into the provided
   index. Function argument get_payload is used to generate the payload for each
@@ -164,6 +167,156 @@ index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType, Position>& inde
 
   for_each_haplotype_window(graph, index.window_bp(), find_minimizers, (threads > 1));
   for(int thread_id = 0; thread_id < threads; thread_id++) { flush_cache(thread_id); }
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  Returns all canonical kmers in the string specified by the iterators. A
+  canonical kmer is the smallest of a kmer and its reverse complement. The
+  return value is a vector of kmers sorted by their offsets.
+*/
+template<class KeyType>
+std::vector<Kmer<KeyType>>
+canonical_kmers(std::string::const_iterator begin, std::string::const_iterator end, size_t k)
+{
+  std::vector<Kmer<KeyType>> result;
+  if(k == 0 || k > KeyType::KMER_MAX_LENGTH)
+  {
+    std::cerr << "canonical_kmers(): k must be between 1 and " << KeyType::KMER_MAX_LENGTH << std::endl;
+    return result;
+  }
+
+  size_t valid_chars = 0, offset = 0;
+  KeyType forward_key, reverse_key;
+  std::string::const_iterator iter = begin;
+  while(iter != end)
+  {
+    forward_key.forward(k, *iter, valid_chars);
+    reverse_key.reverse(k, *iter);
+    if(valid_chars >= k)
+    {
+      if(forward_key < reverse_key)
+      {
+        result.push_back({ forward_key, forward_key.hash(), offset_type(offset - (k - 1)), false });
+      }
+      else
+      {
+        result.push_back({ reverse_key, reverse_key.hash(), offset_type(offset), true });
+      }
+    }
+    ++iter; offset++;
+  }
+
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+/*
+  Returns all canonical kmers in the string. A canonical kmer is the smaller
+  of a kmer and its reverse complement. The return value is a vector of kmers
+  sorted by their offsets.
+*/
+template<class KeyType>
+std::vector<Kmer<KeyType>>
+canonical_kmers(const std::string& seq, size_t k)
+{
+  return canonical_kmers<KeyType>(seq.begin(), seq.end(), k);
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  Index the haplotypes in the graph. Insert the kmers into the provided index.
+  The number of threads can be set through OpenMP.
+*/
+template<class KeyType>
+void
+build_kmer_index(const GBWTGraph& graph, KmerIndex<KeyType, Position>& index, size_t k)
+{
+  typedef KeyType key_type;
+  typedef Kmer<key_type> kmer_type;
+
+  // Kmer caching.
+  int threads = omp_get_max_threads();
+  std::vector<std::vector<std::pair<kmer_type, Position>>> cache(threads);
+  constexpr size_t KMER_CACHE_SIZE = 1024;
+  auto flush_cache = [&](int thread_id)
+  {
+    auto& current_cache = cache[thread_id];
+    gbwt::removeDuplicates(current_cache, false);
+    #pragma omp critical (kmer_index)
+    {
+      for(auto& kmer : current_cache)
+      {
+        index.insert(kmer.first.key, kmer.second, kmer.first.hash);
+      }
+    }
+    cache[thread_id].clear();
+  };
+
+  // Kmer finding.
+  auto find_kmers = [&](const std::vector<handle_t>& traversal, const std::string& seq)
+  {
+    std::vector<kmer_type> kmers = canonical_kmers<key_type>(seq, k);
+    auto iter = traversal.begin();
+    size_t node_start = 0;
+    int thread_id = omp_get_thread_num();
+    for(auto kmer : kmers)
+    {
+      if(kmer.empty()) { continue; }
+
+      // Find the node covering kmer starting position.
+      size_t node_length = graph.get_length(*iter);
+      while(node_start + node_length <= kmer.offset)
+      {
+        node_start += node_length;
+        ++iter;
+        node_length = graph.get_length(*iter);
+      }
+      pos_t pos { graph.get_id(*iter), graph.get_is_reverse(*iter), kmer.offset - node_start };
+      if(kmer.is_reverse) { pos = reverse_base_pos(pos, node_length); }
+      cache[thread_id].emplace_back(kmer, Position::encode(pos));
+    }
+    if(cache[thread_id].size() >= KMER_CACHE_SIZE) { flush_cache(thread_id); }
+  };
+
+  // Count all kmers.
+  for_each_haplotype_window(graph, k, find_kmers, (threads > 1));
+  for(int thread_id = 0; thread_id < threads; thread_id++) { flush_cache(thread_id); }
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  Returns all kmers in the haplotypes with more than `threshold` hits in the
+  graph in sorted order. Considers a kmer and its reverse complement the same.
+  The number of threads can be set through OpenMP.  If the number of kmers can
+  be estimated in advance, providing a hash table size can save time and
+  memory.
+*/
+template<class KeyType>
+std::vector<KeyType>
+frequent_kmers(const GBWTGraph& graph, size_t k, size_t threshold, size_t hash_table_size = KmerIndex<KeyType, Position>::INITIAL_CAPACITY)
+{
+  typedef KmerIndex<KeyType, Position> index_type;
+  typedef typename index_type::cell_type cell_type;
+
+  index_type index(hash_table_size);
+  build_kmer_index(graph, index, k);
+
+  // Find the frequent kmers and sort them.
+  std::vector<KeyType> result;
+  index.for_each_kmer([&](const cell_type& cell)
+  {
+    if(threshold == 0 || (cell.first.is_pointer() && cell.second.pointer->size() > threshold))
+    {
+      result.push_back(cell.first);
+      result.back().clear_pointer();
+    }
+  });
+  gbwt::parallelQuickSort(result.begin(), result.end());
+  return result;
 }
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/index.h
+++ b/include/gbwtgraph/index.h
@@ -19,17 +19,22 @@ namespace gbwtgraph
 //------------------------------------------------------------------------------
 
 /*
-  Index the haplotypes in the graph. Insert the minimizers into the provided index.
-  Function argument get_payload is used to generate the payload for each position
-  stored in the index.
-  The number of threads can be set through OMP.
+  Index the haplotypes in the graph. Insert the minimizers into the provided
+  index. Function argument get_payload is used to generate the payload for each
+  position stored in the index. The number of threads can be set through OpenMP.
+
+  We do a lot of redundant work by traversing both orientations and finding
+  almost the same minimizers in each orientation. If we consider only the
+  windows starting in forward (reverse) orientation, we may miss windows that
+  cross from a reverse node to a forward node (from a forward node to a reverse
+  node).
 */
 template<class KeyType>
 void
-index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType>& index,
+index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType, PositionPayload>& index,
                  const std::function<Payload(const pos_t&)>& get_payload)
 {
-  typedef typename MinimizerIndex<KeyType>::minimizer_type minimizer_type;
+  typedef typename MinimizerIndex<KeyType, PositionPayload>::minimizer_type minimizer_type;
 
   int threads = omp_get_max_threads();
 
@@ -38,16 +43,16 @@ index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType>& index,
   constexpr size_t MINIMIZER_CACHE_SIZE = 1024;
   auto flush_cache = [&](int thread_id)
   {
-    std::vector<std::pair<minimizer_type, pos_t>>& current_cache = cache[thread_id];
+    auto& current_cache = cache[thread_id];
     gbwt::removeDuplicates(current_cache, false);
-    std::vector<Payload> payload;
+    std::vector<Payload> payload; payload.reserve(current_cache.size());
     payload.reserve(current_cache.size());
-    for(size_t i = 0; i < current_cache.size(); i++) { payload.push_back(get_payload(current_cache[i].second)); }
+    for(auto& minimizer : current_cache) { payload.push_back(get_payload(minimizer.second)); }
     #pragma omp critical (minimizer_index)
     {
       for(size_t i = 0; i < current_cache.size(); i++)
       {
-        index.insert(current_cache[i].first, current_cache[i].second, payload[i]);
+        index.insert(current_cache[i].first, { Position::encode(current_cache[i].second), payload[i] });
       }
     }
     cache[thread_id].clear();
@@ -87,17 +92,80 @@ index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType>& index,
     if(cache[thread_id].size() >= MINIMIZER_CACHE_SIZE) { flush_cache(thread_id); }
   };
 
-  /*
-    Index the minimizers.
-    We do a lot of redundant work by traversing both orientations and finding almost the same minimizers
-    in each orientation. If we consider only the windows starting in forward (reverse) orientation,
-    we may skip windows that cross from a reverse node to a forward node (from a forward node to a
-    reverse node).
-  */
   for_each_haplotype_window(graph, index.window_bp(), find_minimizers, (threads > 1));
   for(int thread_id = 0; thread_id < threads; thread_id++) { flush_cache(thread_id); }
 }
   
+//------------------------------------------------------------------------------
+
+/*
+  Index the haplotypes in the graph. Insert the minimizers into the provided
+  index. This version is used for minimizer indexes without payloads. The number
+  of threads can be set through OpenMP.
+*/
+template<class KeyType>
+void
+index_haplotypes(const GBWTGraph& graph, MinimizerIndex<KeyType, Position>& index)
+{
+  typedef typename MinimizerIndex<KeyType, Position>::minimizer_type minimizer_type;
+
+  int threads = omp_get_max_threads();
+
+  // Minimizer caching. We only generate the payloads after we have removed duplicate positions.
+  std::vector<std::vector<std::pair<minimizer_type, Position>>> cache(threads);
+  constexpr size_t MINIMIZER_CACHE_SIZE = 1024;
+  auto flush_cache = [&](int thread_id)
+  {
+    auto& current_cache = cache[thread_id];
+    gbwt::removeDuplicates(current_cache, false);
+    #pragma omp critical (minimizer_index)
+    {
+      for(auto& minimizer : current_cache)
+      {
+        index.insert(minimizer.first, minimizer.second);
+      }
+    }
+    cache[thread_id].clear();
+  };
+
+  // Minimizer finding.
+  auto find_minimizers = [&](const std::vector<handle_t>& traversal, const std::string& seq)
+  {
+    std::vector<minimizer_type> minimizers = index.minimizers(seq); // Calls syncmers() when appropriate.
+    auto iter = traversal.begin();
+    size_t node_start = 0;
+    int thread_id = omp_get_thread_num();
+    for(minimizer_type& minimizer : minimizers)
+    {
+      if(minimizer.empty()) { continue; }
+
+      // Find the node covering minimizer starting position.
+      size_t node_length = graph.get_length(*iter);
+      while(node_start + node_length <= minimizer.offset)
+      {
+        node_start += node_length;
+        ++iter;
+        node_length = graph.get_length(*iter);
+      }
+      pos_t pos { graph.get_id(*iter), graph.get_is_reverse(*iter), minimizer.offset - node_start };
+      if(minimizer.is_reverse) { pos = reverse_base_pos(pos, node_length); }
+      if(!Position::valid_offset(pos))
+      {
+        #pragma omp critical (cerr)
+        {
+          std::cerr << "index_haplotypes(): Node offset " << offset(pos) << " is too large" << std::endl;
+        }
+        std::exit(EXIT_FAILURE);
+      }
+      cache[thread_id].emplace_back(minimizer, Position::encode(pos));
+    }
+    if(cache[thread_id].size() >= MINIMIZER_CACHE_SIZE) { flush_cache(thread_id); }
+  };
+
+  for_each_haplotype_window(graph, index.window_bp(), find_minimizers, (threads > 1));
+  for(int thread_id = 0; thread_id < threads; thread_id++) { flush_cache(thread_id); }
+}
+
 //------------------------------------------------------------------------------
 
 } // namespace gbwtgraph

--- a/include/gbwtgraph/index.h
+++ b/include/gbwtgraph/index.h
@@ -294,6 +294,9 @@ build_kmer_index(const GBWTGraph& graph, KmerIndex<KeyType, Position>& index, si
   The number of threads can be set through OpenMP.  If the number of kmers can
   be estimated in advance, providing a hash table size can save time and
   memory.
+
+  TODO: This is not very efficient, as hash table insertion becomes a
+  bottleneck beyond 3-4 threads.
 */
 template<class KeyType>
 std::vector<KeyType>

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -236,6 +236,19 @@ public:
   /// Decode the key back to a string, given the kmer size used.
   std::string decode(size_t k) const;
 
+  /// Returns the packed character value for kmer[i].
+  code_type access_raw(size_t k, size_t i) const
+  {
+    size_t offset = (k - 1 - i) * KmerEncoding::PACK_WIDTH;
+    return (this->key >> offset) & KmerEncoding::PACK_MASK;
+  }
+
+  /// Returns kmer[i].
+  char access(size_t k, size_t i) const
+  {
+    return KmerEncoding::PACK_TO_CHAR[this->access_raw(k, i)];
+  }
+
   /// Returns the reverse complement of the kmer.
   Key64 reverse_complement(size_t k) const;
 
@@ -346,6 +359,22 @@ public:
 
   /// Decode the key back to a string, given the kmer size used.
   std::string decode(size_t k) const;
+
+  /// Returns the packed character value for kmer[i].
+  code_type access_raw(size_t k, size_t i) const
+  {
+    size_t offset = (k - 1 - i) * KmerEncoding::PACK_WIDTH;
+    code_type shifted;
+    if(offset >= KmerEncoding::FIELD_BITS) { shifted = this->high >> (offset - KmerEncoding::FIELD_BITS); }
+    else { shifted = this->low >> offset; }
+    return shifted & KmerEncoding::PACK_MASK;
+  }
+
+  /// Returns kmer[i].
+  char access(size_t k, size_t i) const
+  {
+    return KmerEncoding::PACK_TO_CHAR[this->access_raw(k, i)];
+  }
 
   /// Returns the reverse complement of the kmer.
   Key128 reverse_complement(size_t k) const;

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -492,7 +492,7 @@ public:
       hash_table_size = INITIAL_CAPACITY;
     }
     this->max_keys = hash_table_size * MAX_LOAD_FACTOR;
-    this->hash_table = new std::vector<cell_type>(hash_table_size, empty_cell());
+    this->hash_table = std::vector<cell_type>(hash_table_size, empty_cell());
   }
 
   KmerIndex(const KmerIndex& source)

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -855,8 +855,8 @@ private:
 
   // Get the hash value for the key. If downweighting is not in use, or
   // the kmer is not frequent, the hash value reported by the key is used
-  // directly. Otherwise we interpret the hash value as a number between
-  // 0.0 and 1.0 and return 1 - (1 - hash)^(2^iterations).
+  // directly. Otherwise we downweight the hash value by the specified
+  // number of iterations.
   size_t hash(key_type key) const
   {
     if(this->frequent_kmers.empty()) { return key.hash(); }
@@ -1024,6 +1024,17 @@ struct MinimizerHeader
   depending on which has the smaller hash.
 
   Minimizers and closed syncmers should have roughly the same seed density when w = k - s.
+
+  There is also an option to use weighted minimizers:
+
+    Jain, Rhie, Zhang, Chu, Walenz, Koren, and Philippy: Weighted minimizer sampling improves
+    long read mapping. Bioinformatics, 2020.
+
+  Normally, a minimizer is the kmer with the smallest hash value. With weighted minimizers,
+  we want to discourage selecting some (frequent) kmers as minimizers. Let x be the hash
+  value interpreted as a number in [0.0, 1.0]. If the kmer is listed as one to be avoided,
+  we downweight it by replacing its hash value with 1.0 - (1.0 - x)^(2^iterations), where
+  iterations is a parameter between 1 and 7 (default 3).
 
   Index versions (this should be in the wiki):
 
@@ -1568,10 +1579,6 @@ public:
     Adds a set of frequent kmers that should be avoided (in both orientations)
     when using weighted minimizers. The index must be empty. Clears the
     frequent kmers if the set of keys is empty or the number of iterations is 0.
-
-    When weighted minimizers are in use, hash values are interpreted as numbers
-    between 0 and 1. For frequent kmers, the hash value reported by key is
-    converted to 1 - (1 - hash)^(2^iterations).
 
     Throws std::runtime_error on failure.
   */

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -1611,7 +1611,7 @@ public:
 
     Throws std::runtime_error on failure.
   */
-  void add_frequent_kmers(const std::vector<key_type>& kmers, size_t k, size_t iterations)
+  void add_frequent_kmers(const std::vector<key_type>& kmers, size_t iterations)
   {
     if(!this->empty())
     {
@@ -1620,11 +1620,6 @@ public:
     if(this->uses_syncmers())
     {
       throw std::runtime_error("MinimizerIndex::add_frequent_kmers(): Cannot use frequent kmers with syncmers");
-    }
-    if(k > key_type::KMER_MAX_LENGTH)
-    {
-      std::string msg = "MinimizerIndex::add_frequent_kmers(): k (" + std::to_string(k) + ") must be at most " + std::to_string(key_type::KMER_MAX_LENGTH);
-      throw std::runtime_error(msg);
     }
     size_t max_iterations = MinimizerHeader::FLAG_WEIGHT_MASK >> MinimizerHeader::FLAG_WEIGHT_OFFSET;
     if(iterations > max_iterations)
@@ -1646,7 +1641,7 @@ public:
     for(key_type key : kmers)
     {
       this->index.insert_frequent(key);
-      this->index.insert_frequent(key.reverse_complement(k));
+      this->index.insert_frequent(key.reverse_complement(this->k()));
     }
     this->index.downweight = iterations;
     this->header.set_int(MinimizerHeader::FLAG_WEIGHT_MASK, MinimizerHeader::FLAG_WEIGHT_OFFSET, iterations);

--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -1572,29 +1572,29 @@ public:
     When weighted minimizers are in use, hash values are interpreted as numbers
     between 0 and 1. For frequent kmers, the hash value reported by key is
     converted to 1 - (1 - hash)^(2^iterations).
+
+    Throws std::runtime_error on failure.
   */
   void add_frequent_kmers(const std::vector<key_type>& kmers, size_t k, size_t iterations)
   {
     if(!this->empty())
     {
-      std::cerr << "MinimizerIndex::add_frequent_kmers(): The index is not empty" << std::endl;
-      return;
+      throw std::runtime_error("MinimizerIndex::add_frequent_kmers(): The index is not empty");
     }
     if(this->uses_syncmers())
     {
-      std::cerr << "MinimizerIndex::add_frequent_kmers(): Cannot use frequent kmers with syncmers" << std::endl;
-      return;
+      throw std::runtime_error("MinimizerIndex::add_frequent_kmers(): Cannot use frequent kmers with syncmers");
     }
     if(k > key_type::KMER_MAX_LENGTH)
     {
-      std::cerr << "MinimizerIndex::add_frequent_kmers(): k (" << k << ") must be at most " << key_type::KMER_MAX_LENGTH << std::endl;
-      return;
+      std::string msg = "MinimizerIndex::add_frequent_kmers(): k (" + std::to_string(k) + ") must be at most " + std::to_string(key_type::KMER_MAX_LENGTH);
+      throw std::runtime_error(msg);
     }
     size_t max_iterations = MinimizerHeader::FLAG_WEIGHT_MASK >> MinimizerHeader::FLAG_WEIGHT_OFFSET;
     if(iterations > max_iterations)
     {
-      std::cerr << "MinimizerIndex::add_frequent_kmers(): Number of iterations (" << iterations << ") must be at most " << max_iterations << std::endl;
-      return;
+      std::string msg = "MinimizerIndex::add_frequent_kmers(): Number of iterations (" + std::to_string(iterations) + ") must be at most " + std::to_string(max_iterations);
+      throw std::runtime_error(msg);
     }
     if(kmers.empty() || iterations == 0)
     {

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -113,7 +113,7 @@ struct Version
 
   constexpr static size_t GBZ_VERSION       = 1;
   constexpr static size_t GRAPH_VERSION     = 3;
-  constexpr static size_t MINIMIZER_VERSION = 8;
+  constexpr static size_t MINIMIZER_VERSION = 9;
 
   const static std::string SOURCE_KEY; // source
   const static std::string SOURCE_VALUE; // jltsiren/gbwtgraph

--- a/src/kmer_freq.cpp
+++ b/src/kmer_freq.cpp
@@ -1,0 +1,228 @@
+#include <iostream>
+#include <fstream>
+#include <map>
+
+#include <getopt.h>
+#include <unistd.h>
+
+#include <gbwtgraph/gbz.h>
+#include <gbwtgraph/index.h>
+
+using namespace gbwtgraph;
+
+//------------------------------------------------------------------------------
+
+const std::string tool_name = "Kmer Frequencies";
+
+struct Config
+{
+  Config(int argc, char** argv);
+
+  constexpr static size_t DEFAULT_K = 19;
+
+  size_t k = DEFAULT_K;
+
+  bool distribution = false;
+  size_t threshold = 0;
+  size_t threads = 1;
+  size_t hash_table_size = KmerIndex<Key64, Position>::INITIAL_CAPACITY;
+
+  bool verbose = true; // TODO: Do we need an option to silence this?
+
+  std::string filename;
+};
+
+void print_distribution(const std::map<size_t, size_t>& distribution, const std::string& header1, const std::string& header2);
+
+//------------------------------------------------------------------------------
+
+int
+main(int argc, char** argv)
+{
+  typedef KmerIndex<Key64, Position> index_type;
+
+  double start = gbwt::readTimer();
+  Config config(argc, argv);
+  omp_set_num_threads(config.threads);
+
+  // Load the graph.
+  GBZ gbz;
+  if(config.verbose)
+  {
+    std::cerr << "Loading GBZ from " << config.filename << std::endl;
+  }
+  sdsl::simple_sds::load_from(gbz, config.filename);
+
+  // Build the kmer index.
+  double checkpoint = gbwt::readTimer();
+  if(config.verbose)
+  {
+    std::cerr << "Building a " << config.k << "-mer index" << std::endl;
+  }
+  index_type index(config.hash_table_size);
+  build_kmer_index(gbz.graph, index, config.k);
+  if(config.verbose)
+  {
+    double seconds = gbwt::readTimer() - checkpoint;
+    std::cerr << "Built the kmer index in " << seconds << " seconds" << std::endl;
+    std::cerr << index.size() << " kmers (" << index.unique_keys() << " unique) with " << index.number_of_values() << " hits" << std::endl;
+  }
+
+  // Determine kmer distribution.
+  std::map<size_t, size_t> distribution;
+  index.for_each_kmer([&](const index_type::cell_type& cell)
+  {
+    if(cell.first.is_pointer()) { distribution[cell.second.pointer->size()]++; }
+    else { distribution[1]++; }
+  });
+
+  if(config.threshold > 0)
+  {
+    size_t count = 0;
+    for(auto iter = distribution.begin(); iter != distribution.end(); ++iter)
+    {
+      if(iter->first > config.threshold) { count += iter->second; }
+    }
+    std::cout << count << std::endl;
+  }
+
+  if(config.distribution)
+  {
+    print_distribution(distribution, "Frequency", "Kmers");
+  }
+
+  // Deleting the hash table may take some time, so we delete it before returning final usage.
+  index = index_type();
+  if(config.verbose)
+  {
+    double seconds = gbwt::readTimer() - start;
+    std::cerr << "Used " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+    std::cerr << std::endl;
+  }
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void
+printUsage(int exit_code)
+{
+  Version::print(std::cerr, tool_name);
+
+  std::cerr << "Usage: kmer_freq [options] graph.gbz" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "Options:" << std::endl;
+  std::cerr << "  -d, --distribution   print kmer frequency distribution" << std::endl;
+  std::cerr << "  -f, --frequent N     count the number of kmers with frequency > N" << std::endl;
+  std::cerr << "  -k, --kmer-length N  count N-mers (default: " << Config::DEFAULT_K << ")" << std::endl;
+  std::cerr << "  -t, --threads N      use N parallel threads" << std::endl;
+  std::cerr << "  -H, --hash-table N   initialize the hash table with 2^N cells" << std::endl;
+  std::cerr << std::endl;
+
+  std::exit(exit_code);
+}
+
+//------------------------------------------------------------------------------
+
+Config::Config(int argc, char** argv)
+{
+  if(argc < 2) { printUsage(EXIT_SUCCESS); }
+
+  size_t max_threads = omp_get_max_threads();
+  size_t min_width = 10;
+  size_t max_width = 36;
+
+  // Data for `getopt_long()`.
+  int c = 0, option_index = 0;
+  option long_options[] =
+  {
+    { "distribution", no_argument, 0, 'd' },
+    { "frequent", required_argument, 0, 'f' },
+    { "kmer-length", required_argument, 0, 'k' },
+    { "threads", required_argument, 0, 't' },
+    { "hash-table", required_argument, 0, 'H' },  };
+
+  // Process options.
+  while((c = getopt_long(argc, argv, "df:k:t:H:", long_options, &option_index)) != -1)
+  {
+    switch(c)
+    {
+    case 'd':
+      this->distribution = true;
+      break;
+    case 'f':
+      try { this->threshold = std::stoul(optarg); }
+      catch(const std::invalid_argument&)
+      {
+        std::cerr << "kmer_freq: Invalid frequency threshold: " << optarg << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      break;
+    case 'k':
+      try { this->k = std::stoul(optarg); }
+      catch(const std::invalid_argument&)
+      {
+        std::cerr << "kmer_freq: Invalid kmer length: " << optarg << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      if(this->k < 2 || this->k > Key64::KMER_MAX_LENGTH)
+      {
+        std::cerr << "kmer_freq: Invalid kmer length: " << this->k << " (must be from 2 to " << Key64::KMER_MAX_LENGTH << ")" << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      break;
+    case 't':
+      try { this->threads = std::stoul(optarg); }
+      catch(const std::invalid_argument&)
+      {
+        std::cerr << "kmer_freq: Invalid number of threads: " << optarg << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      if(this->threads == 0 || this->threads > max_threads)
+      {
+        std::cerr << "kmer_freq: Invalid number of threads: " << this->threads << " (must be from 1 to " << max_threads << ")" << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      break;
+    case 'H':
+      size_t width;
+      try { width = std::stoul(optarg); }
+      catch(const std::invalid_argument&)
+      {
+        std::cerr << "kmer_freq: Invalid hash table width: " << optarg << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      if(width < min_width || width > max_width)
+      {
+        std::cerr << "kmer_freq: Invalid hash table width: " << width << " (must be from " << min_width << " to " << max_width << ")" << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      this->hash_table_size = size_t(1) << width;
+      break;
+
+    case '?':
+      std::exit(EXIT_FAILURE);
+    default:
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  // Sanity checks.
+  if(optind >= argc) { printUsage(EXIT_FAILURE); }
+  this->filename = argv[optind]; optind++;
+}
+
+//------------------------------------------------------------------------------
+
+void
+print_distribution(const std::map<size_t, size_t>& distribution, const std::string& header1, const std::string& header2)
+{
+  std::cout << header1 << "\t" << header2 << std::endl;
+  for(auto iter = distribution.begin(); iter != distribution.end(); ++iter)
+  {
+    std::cout << iter->first << "\t" << iter->second << std::endl;
+  }
+}
+
+//------------------------------------------------------------------------------

--- a/src/minimizer.cpp
+++ b/src/minimizer.cpp
@@ -1,35 +1,20 @@
 #include <gbwtgraph/minimizer.h>
 
-#include <sstream>
-
 namespace gbwtgraph
 {
 
 //------------------------------------------------------------------------------
 
-// MinimizerHeader: Numerical class constants.
+// KmerEncoding: Numerical class constants.
+constexpr size_t KmerEncoding::FIELD_BITS;
+constexpr size_t KmerEncoding::PACK_WIDTH;
+constexpr size_t KmerEncoding::PACK_OVERFLOW;
+constexpr size_t KmerEncoding::FIELD_CHARS;
+constexpr KmerEncoding::value_type KmerEncoding::PACK_MASK;
 
-constexpr std::uint32_t MinimizerHeader::TAG;
-constexpr std::uint32_t MinimizerHeader::VERSION;
-constexpr std::uint64_t MinimizerHeader::FLAG_MASK;
-constexpr std::uint64_t MinimizerHeader::FLAG_KEY_MASK;
-constexpr size_t MinimizerHeader::FLAG_KEY_OFFSET;
-constexpr std::uint64_t MinimizerHeader::FLAG_SYNCMERS;
+// KmerEncoding: Other class variables.
 
-//------------------------------------------------------------------------------
-
-// Position: Numerical class constants.
-
-constexpr size_t Position::OFFSET_BITS;
-constexpr size_t Position::ID_OFFSET;
-constexpr code_type Position::REV_MASK;
-constexpr code_type Position::OFF_MASK;
-
-//------------------------------------------------------------------------------
-
-// Shared conversion tables.
-
-const std::vector<unsigned char> CHAR_TO_PACK =
+const std::vector<unsigned char> KmerEncoding::CHAR_TO_PACK =
 {
   4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
   4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
@@ -52,161 +37,9 @@ const std::vector<unsigned char> CHAR_TO_PACK =
   4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
 };
 
-const std::vector<char> PACK_TO_CHAR = { 'A', 'C', 'G', 'T' };
+const std::vector<char> KmerEncoding::PACK_TO_CHAR = { 'A', 'C', 'G', 'T' };
 
-//------------------------------------------------------------------------------
-
-// Key64: Numerical class constants.
-
-constexpr std::size_t Key64::KEY_BITS;
-constexpr std::size_t Key64::KMER_LENGTH;
-constexpr std::size_t Key64::WINDOW_LENGTH;
-constexpr std::size_t Key64::SMER_LENGTH;
-constexpr std::size_t Key64::KMER_MAX_LENGTH;
-
-constexpr Key64::key_type Key64::EMPTY_KEY;
-constexpr Key64::key_type Key64::NO_KEY;
-constexpr Key64::key_type Key64::KEY_MASK;
-constexpr Key64::key_type Key64::IS_POINTER;
-
-constexpr size_t Key64::PACK_WIDTH;
-constexpr Key64::key_type Key64::PACK_MASK;
-
-// Key64: Other class variables.
-
-const std::vector<Key64::key_type> Key64::KMER_MASK =
-{
-  0x0000000000000000ull,
-  0x0000000000000003ull,
-  0x000000000000000Full,
-  0x000000000000003Full,
-  0x00000000000000FFull,
-  0x00000000000003FFull,
-  0x0000000000000FFFull,
-  0x0000000000003FFFull,
-  0x000000000000FFFFull,
-  0x000000000003FFFFull,
-  0x00000000000FFFFFull,
-  0x00000000003FFFFFull,
-  0x0000000000FFFFFFull,
-  0x0000000003FFFFFFull,
-  0x000000000FFFFFFFull,
-  0x000000003FFFFFFFull,
-  0x00000000FFFFFFFFull,
-  0x00000003FFFFFFFFull,
-  0x0000000FFFFFFFFFull,
-  0x0000003FFFFFFFFFull,
-  0x000000FFFFFFFFFFull,
-  0x000003FFFFFFFFFFull,
-  0x00000FFFFFFFFFFFull,
-  0x00003FFFFFFFFFFFull,
-  0x0000FFFFFFFFFFFFull,
-  0x0003FFFFFFFFFFFFull,
-  0x000FFFFFFFFFFFFFull,
-  0x003FFFFFFFFFFFFFull,
-  0x00FFFFFFFFFFFFFFull,
-  0x03FFFFFFFFFFFFFFull,
-  0x0FFFFFFFFFFFFFFFull,
-  0x3FFFFFFFFFFFFFFFull
-};
-
-//------------------------------------------------------------------------------
-
-// Key128: Numerical class constants.
-
-constexpr std::size_t Key128::FIELD_BITS;
-
-constexpr std::size_t Key128::KEY_BITS;
-constexpr std::size_t Key128::KMER_LENGTH;
-constexpr std::size_t Key128::WINDOW_LENGTH;
-constexpr std::size_t Key128::SMER_LENGTH;
-constexpr std::size_t Key128::KMER_MAX_LENGTH;
-
-constexpr Key128::key_type Key128::EMPTY_KEY;
-constexpr Key128::key_type Key128::NO_KEY;
-constexpr Key128::key_type Key128::KEY_MASK;
-constexpr Key128::key_type Key128::IS_POINTER;
-
-constexpr size_t Key128::PACK_WIDTH;
-constexpr size_t Key128::PACK_OVERFLOW;
-constexpr Key128::key_type Key128::PACK_MASK;
-
-// Key128: Other class variables.
-
-const std::vector<Key128::key_type> Key128::HIGH_MASK =
-{
-  // k = 0
-  0x0000000000000000ull,
-
-  // k = 1 to 32 in the low part of the key.
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-  0x0000000000000000ull,
-
-  // k = 33 to 63 in the high part of the key
-  0x0000000000000003ull,
-  0x000000000000000Full,
-  0x000000000000003Full,
-  0x00000000000000FFull,
-  0x00000000000003FFull,
-  0x0000000000000FFFull,
-  0x0000000000003FFFull,
-  0x000000000000FFFFull,
-  0x000000000003FFFFull,
-  0x00000000000FFFFFull,
-  0x00000000003FFFFFull,
-  0x0000000000FFFFFFull,
-  0x0000000003FFFFFFull,
-  0x000000000FFFFFFFull,
-  0x000000003FFFFFFFull,
-  0x00000000FFFFFFFFull,
-  0x00000003FFFFFFFFull,
-  0x0000000FFFFFFFFFull,
-  0x0000003FFFFFFFFFull,
-  0x000000FFFFFFFFFFull,
-  0x000003FFFFFFFFFFull,
-  0x00000FFFFFFFFFFFull,
-  0x00003FFFFFFFFFFFull,
-  0x0000FFFFFFFFFFFFull,
-  0x0003FFFFFFFFFFFFull,
-  0x000FFFFFFFFFFFFFull,
-  0x003FFFFFFFFFFFFFull,
-  0x00FFFFFFFFFFFFFFull,
-  0x03FFFFFFFFFFFFFFull,
-  0x0FFFFFFFFFFFFFFFull,
-  0x3FFFFFFFFFFFFFFFull
-};
-
-const std::vector<Key128::key_type> Key128::LOW_MASK =
+const std::vector<KmerEncoding::value_type> KmerEncoding::LOW_MASK =
 {
   // k = 0
   0x0000000000000000ull,
@@ -278,6 +111,129 @@ const std::vector<Key128::key_type> Key128::LOW_MASK =
   0xFFFFFFFFFFFFFFFFull,
   0xFFFFFFFFFFFFFFFFull
 };
+
+const std::vector<KmerEncoding::value_type> KmerEncoding::HIGH_MASK =
+{
+  // k = 0
+  0x0000000000000000ull,
+
+  // k = 1 to 32 in the low part of the key.
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+  0x0000000000000000ull,
+
+  // k = 33 to 63 in the high part of the key
+  0x0000000000000003ull,
+  0x000000000000000Full,
+  0x000000000000003Full,
+  0x00000000000000FFull,
+  0x00000000000003FFull,
+  0x0000000000000FFFull,
+  0x0000000000003FFFull,
+  0x000000000000FFFFull,
+  0x000000000003FFFFull,
+  0x00000000000FFFFFull,
+  0x00000000003FFFFFull,
+  0x0000000000FFFFFFull,
+  0x0000000003FFFFFFull,
+  0x000000000FFFFFFFull,
+  0x000000003FFFFFFFull,
+  0x00000000FFFFFFFFull,
+  0x00000003FFFFFFFFull,
+  0x0000000FFFFFFFFFull,
+  0x0000003FFFFFFFFFull,
+  0x000000FFFFFFFFFFull,
+  0x000003FFFFFFFFFFull,
+  0x00000FFFFFFFFFFFull,
+  0x00003FFFFFFFFFFFull,
+  0x0000FFFFFFFFFFFFull,
+  0x0003FFFFFFFFFFFFull,
+  0x000FFFFFFFFFFFFFull,
+  0x003FFFFFFFFFFFFFull,
+  0x00FFFFFFFFFFFFFFull,
+  0x03FFFFFFFFFFFFFFull,
+  0x0FFFFFFFFFFFFFFFull,
+  0x3FFFFFFFFFFFFFFFull
+};
+
+//------------------------------------------------------------------------------
+
+// MinimizerHeader: Numerical class constants.
+
+constexpr std::uint32_t MinimizerHeader::TAG;
+constexpr std::uint32_t MinimizerHeader::VERSION;
+constexpr std::uint64_t MinimizerHeader::FLAG_MASK;
+constexpr std::uint64_t MinimizerHeader::FLAG_KEY_MASK;
+constexpr size_t MinimizerHeader::FLAG_KEY_OFFSET;
+constexpr std::uint64_t MinimizerHeader::FLAG_SYNCMERS;
+
+//------------------------------------------------------------------------------
+
+// Position: Numerical class constants.
+
+constexpr size_t Position::OFFSET_BITS;
+constexpr size_t Position::ID_OFFSET;
+constexpr Position::code_type Position::REV_MASK;
+constexpr Position::code_type Position::OFF_MASK;
+
+//------------------------------------------------------------------------------
+
+// Key64: Numerical class constants.
+
+constexpr std::size_t Key64::KEY_BITS;
+constexpr std::size_t Key64::KMER_LENGTH;
+constexpr std::size_t Key64::WINDOW_LENGTH;
+constexpr std::size_t Key64::SMER_LENGTH;
+constexpr std::size_t Key64::KMER_MAX_LENGTH;
+
+constexpr Key64::code_type Key64::EMPTY_KEY;
+constexpr Key64::code_type Key64::NO_KEY;
+constexpr Key64::code_type Key64::KEY_MASK;
+constexpr Key64::code_type Key64::IS_POINTER;
+
+//------------------------------------------------------------------------------
+
+// Key128: Numerical class constants.
+
+constexpr std::size_t Key128::KEY_BITS;
+constexpr std::size_t Key128::KMER_LENGTH;
+constexpr std::size_t Key128::WINDOW_LENGTH;
+constexpr std::size_t Key128::SMER_LENGTH;
+constexpr std::size_t Key128::KMER_MAX_LENGTH;
+
+constexpr Key128::code_type Key128::EMPTY_KEY;
+constexpr Key128::code_type Key128::NO_KEY;
+constexpr Key128::code_type Key128::KEY_MASK;
+constexpr Key128::code_type Key128::IS_POINTER;
 
 //------------------------------------------------------------------------------
 
@@ -399,15 +355,15 @@ MinimizerHeader::operator==(const MinimizerHeader& another) const
 Key64
 Key64::encode(const std::string& sequence)
 {
-  key_type packed = 0;
+  code_type packed = 0;
   for(auto c : sequence)
   {
-    auto packed_char = CHAR_TO_PACK[static_cast<std::uint8_t>(c)];
-    if(packed_char > PACK_MASK)
+    auto packed_char = KmerEncoding::CHAR_TO_PACK[static_cast<std::uint8_t>(c)];
+    if(packed_char > KmerEncoding::PACK_MASK)
     {
       throw std::runtime_error("Key64::encode(): Cannot encode character '" + std::to_string(c) + "'");
     }
-    packed = (packed << PACK_WIDTH) | packed_char;
+    packed = (packed << KmerEncoding::PACK_WIDTH) | packed_char;
   }
   return Key64(packed);
 }
@@ -415,12 +371,12 @@ Key64::encode(const std::string& sequence)
 std::string
 Key64::decode(size_t k) const
 {
-  std::stringstream result;
+  std::string result; result.reserve(k);
   for(size_t i = 0; i < k; i++)
   {
-    result << PACK_TO_CHAR[(this->key >> ((k - i - 1) * PACK_WIDTH)) & PACK_MASK];
+    result.push_back(KmerEncoding::PACK_TO_CHAR[(this->key >> ((k - i - 1) * KmerEncoding::PACK_WIDTH)) & KmerEncoding::PACK_MASK]);
   }
-  return result.str();
+  return result;
 }
 
 std::ostream&
@@ -433,23 +389,23 @@ operator<<(std::ostream& out, Key64 value)
 Key128
 Key128::encode(const std::string& sequence)
 {
-  size_t low_limit = (sequence.size() > FIELD_CHARS ? FIELD_CHARS : sequence.size());
+  size_t low_limit = (sequence.size() > KmerEncoding::FIELD_CHARS ? KmerEncoding::FIELD_CHARS : sequence.size());
   
-  key_type packed_high = 0;
-  key_type packed_low = 0;
+  code_type packed_high = 0;
+  code_type packed_low = 0;
   
   for(size_t i = 0; i < sequence.size(); i++)
   {
     auto c = sequence[i];
-    auto packed_char = CHAR_TO_PACK[static_cast<std::uint8_t>(c)];
-    if(packed_char > PACK_MASK)
+    auto packed_char = KmerEncoding::CHAR_TO_PACK[static_cast<std::uint8_t>(c)];
+    if(packed_char > KmerEncoding::PACK_MASK)
     {
       throw std::runtime_error("Key128::encode(): Cannot encode character '" + std::to_string(c) + "'");
     }
     
-    key_type& pack_to = (i < sequence.size() - low_limit) ? packed_high : packed_low;
+    code_type& pack_to = (i < sequence.size() - low_limit) ? packed_high : packed_low;
     
-    pack_to = (pack_to << PACK_WIDTH) | packed_char;
+    pack_to = (pack_to << KmerEncoding::PACK_WIDTH) | packed_char;
   }
   
   return Key128(packed_high, packed_low);
@@ -458,17 +414,17 @@ Key128::encode(const std::string& sequence)
 std::string
 Key128::decode(size_t k) const
 {
-  std::stringstream result;
-  size_t low_limit = (k > FIELD_CHARS ? FIELD_CHARS : k);
-  for(size_t i = FIELD_CHARS; i < k; i++)
+  std::string result; result.reserve(k);
+  size_t low_limit = (k > KmerEncoding::FIELD_CHARS ? KmerEncoding::FIELD_CHARS : k);
+  for(size_t i = KmerEncoding::FIELD_CHARS; i < k; i++)
   {
-    result << PACK_TO_CHAR[(this->high >> ((k - i - 1) * PACK_WIDTH)) & PACK_MASK];
+    result.push_back(KmerEncoding::PACK_TO_CHAR[(this->high >> ((k - i - 1) * KmerEncoding::PACK_WIDTH)) & KmerEncoding::PACK_MASK]);
   }
   for(size_t i = 0; i < low_limit; i++)
   {
-    result << PACK_TO_CHAR[(this->low >> ((low_limit - i - 1) * PACK_WIDTH)) & PACK_MASK];
+    result.push_back(KmerEncoding::PACK_TO_CHAR[(this->low >> ((low_limit - i - 1) * KmerEncoding::PACK_WIDTH)) & KmerEncoding::PACK_MASK]);
   }
-  return result.str();
+  return result;
 }
 
 std::ostream&
@@ -481,13 +437,13 @@ operator<<(std::ostream& out, Key128 value)
 //------------------------------------------------------------------------------
 
 void
-hits_in_subgraph(size_t hit_count, const hit_type* hits, const std::unordered_set<nid_t>& subgraph,
-                 const std::function<void(pos_t, payload_type)>& report_hit)
+hits_in_subgraph(size_t hit_count, const PositionPayload* hits, const std::unordered_set<nid_t>& subgraph,
+                 const std::function<void(pos_t, Payload)>& report_hit)
 {
-  for(const hit_type* ptr = hits; ptr < hits + hit_count; ++ptr)
+  for(const PositionPayload* ptr = hits; ptr < hits + hit_count; ++ptr)
   {
-    auto iter = subgraph.find(Position::id(ptr->pos));
-    if(iter != subgraph.end()) { report_hit(Position::decode(ptr->pos), ptr->payload); }
+    auto iter = subgraph.find(ptr->position.id());
+    if(iter != subgraph.end()) { report_hit(ptr->position.decode(), ptr->payload); }
   }
 }
 
@@ -522,18 +478,18 @@ exponential_search(size_t start, size_t limit, nid_t target, const std::function
 }
 
 void
-hits_in_subgraph(size_t hit_count, const hit_type* hits, const std::vector<nid_t>& subgraph,
-                 const std::function<void(pos_t, payload_type)>& report_hit)
+hits_in_subgraph(size_t hit_count, const PositionPayload* hits, const std::vector<nid_t>& subgraph,
+                 const std::function<void(pos_t, Payload)>& report_hit)
 {
   size_t hit_offset = 0, subgraph_offset = 0;
   while(hit_offset < hit_count && subgraph_offset < subgraph.size())
   {
-    nid_t node = Position::id(hits[hit_offset].pos);
+    nid_t node = hits[hit_offset].position.id();
     if(node < subgraph[subgraph_offset])
     {
       hit_offset = exponential_search(hit_offset, hit_count, subgraph[subgraph_offset], [&](size_t offset) -> nid_t
       {
-        return Position::id(hits[offset].pos);
+        return hits[offset].position.id();
       });
     }
     else if(node > subgraph[subgraph_offset])
@@ -545,7 +501,7 @@ hits_in_subgraph(size_t hit_count, const hit_type* hits, const std::vector<nid_t
     }
     else
     {
-      report_hit(Position::decode(hits[hit_offset].pos), hits[hit_offset].payload);
+      report_hit(hits[hit_offset].position.decode(), hits[hit_offset].payload);
       ++hit_offset;
     }
   }

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -17,7 +17,9 @@ namespace
 
 //------------------------------------------------------------------------------
 
-typedef gbwtgraph::view_type view_type;
+using handlegraph::pos_t;
+using gbwtgraph::view_type;
+
 typedef std::pair<gbwtgraph::nid_t, std::string> node_type;
 typedef std::pair<std::string, std::pair<gbwtgraph::nid_t, gbwtgraph::nid_t>> translation_type;
 

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -350,17 +350,29 @@ build_source(gbwtgraph::SequenceSource& source, bool with_translation = false)
 //------------------------------------------------------------------------------
 
 template<class KeyType>
-gbwtgraph::Minimizer<KeyType>
+gbwtgraph::Kmer<KeyType>
 get_minimizer(KeyType key, gbwtgraph::offset_type offset = 0, bool orientation = false)
 {
   return { key, key.hash(), offset, orientation };
 }
 
 template<class KeyType>
-gbwtgraph::Minimizer<KeyType>
+gbwtgraph::Kmer<KeyType>
 get_minimizer(std::string key, gbwtgraph::offset_type offset = 0, bool orientation = false)
 {
   return get_minimizer(KeyType::encode(key), offset, orientation);
+}
+
+std::string
+path_to_string(const gbwtgraph::GBWTGraph& graph, const gbwt::vector_type& path)
+{
+  std::string str;
+  for(gbwt::node_type node : path)
+  {
+    view_type view = graph.get_sequence_view(gbwtgraph::GBWTGraph::node_to_handle(node));
+    str.append(view.first, view.second);
+  }
+  return str;
 }
 
 //------------------------------------------------------------------------------

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -350,15 +350,15 @@ build_source(gbwtgraph::SequenceSource& source, bool with_translation = false)
 //------------------------------------------------------------------------------
 
 template<class KeyType>
-typename gbwtgraph::MinimizerIndex<KeyType>::minimizer_type
-get_minimizer(KeyType key, typename gbwtgraph::MinimizerIndex<KeyType>::offset_type offset = 0, bool orientation = false)
+gbwtgraph::Minimizer<KeyType>
+get_minimizer(KeyType key, gbwtgraph::offset_type offset = 0, bool orientation = false)
 {
   return { key, key.hash(), offset, orientation };
 }
 
 template<class KeyType>
-typename gbwtgraph::MinimizerIndex<KeyType>::minimizer_type
-get_minimizer(std::string key, typename gbwtgraph::MinimizerIndex<KeyType>::offset_type offset = 0, bool orientation = false)
+gbwtgraph::Minimizer<KeyType>
+get_minimizer(std::string key, gbwtgraph::offset_type offset = 0, bool orientation = false)
 {
   return get_minimizer(KeyType::encode(key), offset, orientation);
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -18,7 +18,7 @@ namespace
 class IndexConstruction : public ::testing::Test
 {
 public:
-  typedef std::map<DefaultMinimizerIndex::key_type, std::set<std::pair<pos_t, payload_type>>> result_type;
+  typedef std::map<DefaultMinimizerIndex::key_type, std::set<std::pair<pos_t, Payload>>> result_type;
 
   gbwt::GBWT index;
   SequenceSource source;
@@ -64,7 +64,7 @@ public:
       }
       pos_t pos { this->graph.get_id(handle), this->graph.get_is_reverse(handle), minimizer.offset - node_start };
       if(minimizer.is_reverse) { pos = reverse_base_pos(pos, node_length); }
-      result[minimizer.key].emplace(pos, payload_type::create(hash(pos)));
+      result[minimizer.key].emplace(pos, Payload::create(hash(pos)));
     }
   }
 
@@ -80,8 +80,8 @@ public:
 
     for(auto iter = correct_values.begin(); iter != correct_values.end(); ++iter)
     {
-      std::vector<std::pair<pos_t, payload_type>> result = this->mi.find(get_minimizer(iter->first));
-      std::vector<std::pair<pos_t, payload_type>> correct(iter->second.begin(), iter->second.end());
+      std::vector<std::pair<pos_t, Payload>> result = this->mi.find(get_minimizer(iter->first));
+      std::vector<std::pair<pos_t, Payload>> correct(iter->second.begin(), iter->second.end());
       EXPECT_EQ(result, correct) << "Wrong positions for key " << iter->first;
     }
   }
@@ -90,14 +90,14 @@ public:
 TEST_F(IndexConstruction, DefaultMinimizerIndex)
 {
   // Determine the correct minimizer occurrences.
-  std::map<DefaultMinimizerIndex::key_type, std::set<std::pair<pos_t, payload_type>>> correct_values;
+  std::map<DefaultMinimizerIndex::key_type, std::set<std::pair<pos_t, Payload>>> correct_values;
   this->insert_values(alt_path, correct_values);
   this->insert_values(short_path, correct_values);
 
   // Check that we managed to index them.
-  index_haplotypes(this->graph, this->mi, [](const pos_t& pos) -> payload_type
+  index_haplotypes(this->graph, this->mi, [](const pos_t& pos) -> Payload
   {
-    return payload_type::create(hash(pos));
+    return Payload::create(hash(pos));
   });
   this->check_minimizer_index(correct_values);
 }

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -38,6 +38,69 @@ create_value<PositionPayload>(pos_t pos, Payload payload)
 //------------------------------------------------------------------------------
 
 template<class KeyType>
+class KmerExtraction : public ::testing::Test
+{
+
+};
+
+TYPED_TEST_CASE(KmerExtraction, KeyTypes);
+
+TYPED_TEST(KmerExtraction, CanonicalKmers)
+{
+  typedef TypeParam key_type;
+
+  std::string sequence = "GATTACAGATTA";
+  std::vector<Kmer<key_type>> truth
+  {
+    { key_type::encode("ATC"), 0, 2, true },
+    { key_type::encode("AAT"), 0, 3, true },
+    { key_type::encode("TAA"), 0, 4, true },
+    { key_type::encode("GTA"), 0, 5, true },
+    { key_type::encode("ACA"), 0, 4, false },
+    { key_type::encode("CAG"), 0, 5, false },
+    { key_type::encode("AGA"), 0, 6, false },
+    { key_type::encode("ATC"), 0, 9, true },
+    { key_type::encode("AAT"), 0, 10, true },
+    { key_type::encode("TAA"), 0, 11, true },
+  };
+  std::sort(truth.begin(), truth.end());
+
+  auto kmers = canonical_kmers<TypeParam>(sequence, 3);
+  ASSERT_EQ(kmers.size(), truth.size()) << "Invalid number of kmers";
+  for(size_t i = 0; i < truth.size(); i++)
+  {
+    EXPECT_EQ(kmers[i], truth[i]) << "Kmer " << i << ": expected " << truth[i] << ", got " << kmers[i];
+  }
+}
+
+TYPED_TEST(KmerExtraction, InvalidCharacters)
+{
+  typedef TypeParam key_type;
+
+  std::string sequence = "GATTAxAGATTA";
+  std::vector<Kmer<key_type>> truth
+  {
+    { key_type::encode("ATC"), 0, 2, true },
+    { key_type::encode("AAT"), 0, 3, true },
+    { key_type::encode("TAA"), 0, 4, true },
+    { key_type::encode("AGA"), 0, 6, false },
+    { key_type::encode("ATC"), 0, 9, true },
+    { key_type::encode("AAT"), 0, 10, true },
+    { key_type::encode("TAA"), 0, 11, true },
+  };
+  std::sort(truth.begin(), truth.end());
+
+  auto kmers = canonical_kmers<TypeParam>(sequence, 3);
+  ASSERT_EQ(kmers.size(), truth.size()) << "Invalid number of kmers";
+  for(size_t i = 0; i < truth.size(); i++)
+  {
+    EXPECT_EQ(kmers[i], truth[i]) << "Kmer " << i << ": expected " << truth[i] << ", got " << kmers[i];
+  }
+}
+
+//------------------------------------------------------------------------------
+
+template<class KeyType>
 class IndexConstruction : public ::testing::Test
 {
 public:
@@ -53,42 +116,64 @@ public:
   }
 
   template<class ValueType>
-  void insert_values(const MinimizerIndex<KeyType, ValueType>& index, const gbwt::vector_type& path, std::map<KeyType, std::set<ValueType>>& result) const
+  static std::vector<Kmer<KeyType>> get_kmers(const KmerIndex<KeyType, ValueType>&, const std::string& str, size_t k)
   {
-    typedef typename MinimizerIndex<KeyType, ValueType>::minimizer_type minimizer_type;
+    return canonical_kmers<KeyType>(str, k);
+  }
+
+  template<class ValueType>
+  static std::vector<Kmer<KeyType>> get_kmers(const MinimizerIndex<KeyType, ValueType>& index, const std::string& str, size_t)
+  {
+    return index.minimizers(str);
+  }
+
+  template<class IndexType>
+  void insert_values(const IndexType& index, const gbwt::vector_type& path, std::map<KeyType, std::set<typename IndexType::value_type>>& result, size_t k) const
+  {
+    typedef typename IndexType::value_type value_type;
 
     // Convert the path to a string and find the minimizers.
-    std::string str;
-    for(gbwt::node_type node : path)
-    {
-      str += this->graph.get_sequence(GBWTGraph::node_to_handle(node));
-    }
-    std::vector<minimizer_type> minimizers = index.minimizers(str);
+    std::string str = path_to_string(this->graph, path);
+    auto kmers = get_kmers(index, str, k);
 
     // Insert the minimizers into the result.
     auto iter = path.begin();
     size_t node_start = 0;
-    for(auto minimizer : minimizers)
+    for(auto kmer : kmers)
     {
-      if(minimizer.empty()) { continue; }
+      if(kmer.empty()) { continue; }
       handle_t handle = GBWTGraph::node_to_handle(*iter);
       size_t node_length = this->graph.get_length(handle);
-      while(node_start + node_length <= minimizer.offset)
+      while(node_start + node_length <= kmer.offset)
       {
         node_start += node_length;
         ++iter;
         handle = GBWTGraph::node_to_handle(*iter);
         node_length = this->graph.get_length(handle);
       }
-      pos_t pos { this->graph.get_id(handle), this->graph.get_is_reverse(handle), minimizer.offset - node_start };
-      if(minimizer.is_reverse) { pos = reverse_base_pos(pos, node_length); }
-      result[minimizer.key].emplace(create_value<ValueType>(pos, Payload::create(hash(pos))));
+      pos_t pos { this->graph.get_id(handle), this->graph.get_is_reverse(handle), kmer.offset - node_start };
+      if(kmer.is_reverse) { pos = reverse_base_pos(pos, node_length); }
+      result[kmer.key].emplace(create_value<value_type>(pos, Payload::create(hash(pos))));
     }
   }
 
   template<class ValueType>
-  void check_minimizer_index(const MinimizerIndex<KeyType, ValueType>& index, const std::map<KeyType, std::set<ValueType>>& correct_values)
+  static std::pair<const ValueType*, size_t> find_values(const KmerIndex<KeyType, ValueType>& index, KeyType key)
   {
+    return index.find(key);
+  }
+
+  template<class ValueType>
+  static std::pair<const ValueType*, size_t> find_values(const MinimizerIndex<KeyType, ValueType>& index, KeyType key)
+  {
+    return index.find(get_minimizer<KeyType>(key));
+  }
+
+  template<class IndexType>
+  void check_index(const IndexType& index, const std::map<KeyType, std::set<typename IndexType::value_type>>& correct_values) const
+  {
+    typedef typename IndexType::value_type value_type;
+
     size_t values = 0;
     for(auto iter = correct_values.begin(); iter != correct_values.end(); ++iter)
     {
@@ -99,9 +184,9 @@ public:
 
     for(auto iter = correct_values.begin(); iter != correct_values.end(); ++iter)
     {
-      auto values = index.find(get_minimizer<KeyType>(iter->first));
-      std::vector<ValueType> result(values.first, values.first + values.second);
-      std::vector<ValueType> correct(iter->second.begin(), iter->second.end());
+      auto values = find_values(index, iter->first);
+      std::vector<value_type> result(values.first, values.first + values.second);
+      std::vector<value_type> correct(iter->second.begin(), iter->second.end());
       EXPECT_EQ(result, correct) << "Wrong positions for key " << iter->first;
     }
   }
@@ -114,12 +199,12 @@ TYPED_TEST(IndexConstruction, WithoutPayload)
   // Determine the correct minimizer occurrences.
   MinimizerIndex<TypeParam, Position> index(3, 2);
   std::map<TypeParam, std::set<Position>> correct_values;
-  this->insert_values(index, alt_path, correct_values);
-  this->insert_values(index, short_path, correct_values);
+  this->insert_values(index, alt_path, correct_values, index.k());
+  this->insert_values(index, short_path, correct_values, index.k());
 
   // Check that we managed to index them.
   index_haplotypes(this->graph, index);
-  this->check_minimizer_index(index, correct_values);
+  this->check_index(index, correct_values);
 }
 
 TYPED_TEST(IndexConstruction, WithPayload)
@@ -127,15 +212,68 @@ TYPED_TEST(IndexConstruction, WithPayload)
   // Determine the correct minimizer occurrences.
   MinimizerIndex<TypeParam, PositionPayload> index(3, 2);
   std::map<TypeParam, std::set<PositionPayload>> correct_values;
-  this->insert_values(index, alt_path, correct_values);
-  this->insert_values(index, short_path, correct_values);
+  this->insert_values(index, alt_path, correct_values, index.k());
+  this->insert_values(index, short_path, correct_values, index.k());
 
   // Check that we managed to index them.
   index_haplotypes(this->graph, index, [](const pos_t& pos) -> Payload
   {
     return Payload::create(hash(pos));
   });
-  this->check_minimizer_index(index, correct_values);
+  this->check_index(index, correct_values);
+}
+
+TYPED_TEST(IndexConstruction, CanonicalKmerIndex)
+{
+  // Determine the correct canonical kmers.
+  KmerIndex<TypeParam, Position> index;
+  std::map<TypeParam, std::set<Position>> correct_values;
+  this->insert_values(index, alt_path, correct_values, 3);
+  this->insert_values(index, short_path, correct_values, 3);
+
+  // Check that we managed to index them.
+  build_kmer_index(this->graph, index, 3);
+  this->check_index(index, correct_values);
+}
+
+//------------------------------------------------------------------------------
+
+template<class KeyType>
+class KmerCounting : public ::testing::Test
+{
+public:
+  gbwt::GBWT index;
+  SequenceSource source;
+  GBWTGraph graph;
+
+  void SetUp() override
+  {
+    this->index = build_gbwt_index();
+    build_source(this->source);
+    this->graph = GBWTGraph(this->index, this->source);
+  }
+};
+
+TYPED_TEST_CASE(KmerCounting, KeyTypes);
+
+TYPED_TEST(KmerCounting, FrequentKmers)
+{
+  // alt_path:   G A GGG T A - A A
+  // short_path: G - GGG T A C - A
+  // CCC: two reverse occurrences
+  // GTA: one forward and one reverse occurrence
+
+  size_t k = 3;
+  std::vector<TypeParam> correct;
+  correct.push_back(TypeParam::encode("CCC"));
+  correct.push_back(TypeParam::encode("GTA"));
+
+  auto kmers = frequent_kmers<TypeParam>(this->graph, k, 1);
+  ASSERT_EQ(kmers.size(), correct.size()) << "Invalid number of frequent kmers";
+  for(size_t i = 0; i < kmers.size(); i++)
+  {
+    EXPECT_EQ(kmers[i], correct[i]) << "Invalid kmer " << i << ": expected " << correct[i].decode(k) << ", got " << kmers[i].decode(k);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -503,6 +503,19 @@ TYPED_TEST(KeyEncodeDecode, ComplexSequence)
   }
 }
 
+TYPED_TEST(KeyEncodeDecode, RandomAccess)
+{
+  for(size_t k = 1; k <= TypeParam::KMER_MAX_LENGTH; k++)
+  {
+    std::string kmer = this->get_string(k);
+    TypeParam encoded = TypeParam::encode(kmer);
+    for(size_t i = 0; i < k; i++)
+    {
+      ASSERT_EQ(encoded.access(k, i), kmer[i]) << "Invalid access(" << k << ", " << i << ")";
+    }
+  }
+}
+
 TYPED_TEST(KeyEncodeDecode, ReverseComplement)
 {
   for(size_t k = 1; k <= TypeParam::KMER_MAX_LENGTH; k++)

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -441,7 +441,7 @@ TYPED_TEST(Serialization, WeightedMinimizers)
 
   index_type index(15, 6);
   ASSERT_FALSE(index.uses_weighted_minimizers()) << "Weighted minimizers are in use by default";
-  index.add_frequent_kmers({ key_type::encode("GATTACACATGATTA"), key_type::encode("TATTAGATTACATTA") }, 15, 3);
+  index.add_frequent_kmers({ key_type::encode("GATTACACATGATTA"), key_type::encode("TATTAGATTACATTA") }, 3);
   ASSERT_TRUE(index.uses_weighted_minimizers()) << "Weighted minimizers could not be enabled";
 
   index.insert(get_minimizer<key_type>(1), create_value<value_type>(make_pos_t(1, false, 3), Payload::create(hash(1, false, 3))));
@@ -639,7 +639,7 @@ TYPED_TEST(MinimizerExtraction, WeightedMinimizers)
   typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 2);
-  index.add_frequent_kmers({ key_type::encode("ATA") }, 3, 3);
+  index.add_frequent_kmers({ key_type::encode("ATA") }, 3);
   std::vector<minimizer_type> correct;
   if(key_type::KEY_BITS == 128)
   {

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -540,7 +540,7 @@ TYPED_TEST(MinimizerExtraction, AllMinimizers)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 2);
   std::vector<minimizer_type> correct;
@@ -582,7 +582,7 @@ TYPED_TEST(MinimizerExtraction, ClosedSyncmers)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(5, 3, true);
   std::vector<minimizer_type> correct;
@@ -622,7 +622,7 @@ TYPED_TEST(MinimizerExtraction, AllMinimizersWithRegions)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 2);
   std::vector<std::tuple<minimizer_type, size_t, size_t>> correct;
@@ -703,7 +703,7 @@ TEST(MinimizerExtraction, HardMinimizersWithRegion)
   using TypeParam = MinimizerIndex<Key128, Position>;
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   // Here's a case I caught not working correctly.
   index_type index(29, 11);
@@ -740,7 +740,7 @@ TYPED_TEST(MinimizerExtraction, WindowLength)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 3);
   std::vector<minimizer_type> correct;
@@ -776,7 +776,7 @@ TYPED_TEST(MinimizerExtraction, AllOccurrences)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 3);
   std::vector<minimizer_type> correct;
@@ -808,7 +808,7 @@ TYPED_TEST(MinimizerExtraction, WeirdSyncmers)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   // The string is the reverse complement of itself. The middle smers AAT and ATT
   // are the smallest ones using both key types.
@@ -839,7 +839,7 @@ TYPED_TEST(MinimizerExtraction, InvalidMinimizerCharacters)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   std::string weird = "CGAATAxAATACT";
   index_type index(3, 2);
@@ -876,7 +876,7 @@ TYPED_TEST(MinimizerExtraction, InvalidSyncmerCharacters)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   std::string weird = "CGAATAxAATACT";
   index_type index(5, 3, true);
@@ -907,7 +907,7 @@ TYPED_TEST(MinimizerExtraction, BothOrientations)
 {
   typedef TypeParam index_type;
   typedef typename index_type::key_type key_type;
-  typedef Minimizer<key_type> minimizer_type;
+  typedef Kmer<key_type> minimizer_type;
 
   index_type index(3, 2);
   std::vector<minimizer_type> forward_minimizers = index.minimizers(this->str.begin(), this->str.end());

--- a/tests/test_minimizer.cpp
+++ b/tests/test_minimizer.cpp
@@ -5,7 +5,6 @@
 #include <map>
 #include <random>
 #include <set>
-#include <sstream>
 #include <tuple>
 #include <unordered_set>
 #include <vector>
@@ -560,15 +559,14 @@ TYPED_TEST(MinimizerExtraction, KeyEncoding)
 
   key_type forward_key, reverse_key;
   size_t valid_chars = 0;
-  std::stringstream result;
+  std::string correct;
   for(size_t i = 0; i < 2 * k + 1; i++)
   {
     char c = bases[i % bases.length()];
     forward_key.forward(k, c, valid_chars);
     reverse_key.reverse(k, c);
-    result << c;
+    correct += c;
   }
-  std::string correct = result.str();
   correct = correct.substr(correct.length() - k);
   std::string reverse = reverse_complement(correct);
 


### PR DESCRIPTION
Refactor the minimizer index:

* Expose the kmer encoding as `KmerEncoding`.
* Extract a generic kmer (`KmerIndex`) index parameterized by key type (`Key64` or `Key128`) and value type (`Position` or `PositionPayload`).
* Use the kmer index within the minimizer index and parameterize it also with both key and value types.
* Allow building smaller minimizer indexes without payloads.
* Simplify the minimizer index query options and rename some statistics.
* New minimizer index version (9) compatible with the previous version.

Add support for weighted minimizers:

* A set of frequent kmers can be added to an empty minimizer index.
* When frequent kmers have been defined, the index will try to avoid selecting them as minimizers.