### PR TITLE
Subgraph queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ test_gfa
 test_index
 test_minimizer
 test_path_cover
+test_subgraph
 test_utils
 
 # Mac

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 CXX_FLAGS=$(MY_CXX_FLAGS) $(PARALLEL_FLAGS) $(MY_CXX_OPT_FLAGS) -Iinclude -I$(INC_DIR)
 
 HEADERS=$(wildcard include/gbwtgraph/*.h)
-LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o internal.o minimizer.o path_cover.o utils.o)
+LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o internal.o minimizer.o path_cover.o subgraph.o utils.o)
 LIBRARY=$(BUILD_LIB)/libgbwtgraph.a
 
 PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt gbz_stats kmer_freq)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ HEADERS=$(wildcard include/gbwtgraph/*.h)
 LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o internal.o minimizer.o path_cover.o subgraph.o utils.o)
 LIBRARY=$(BUILD_LIB)/libgbwtgraph.a
 
-PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt gbz_stats kmer_freq)
+PROGRAMS=$(addprefix $(BUILD_BIN)/,gfa2gbwt gbz_stats kmer_freq subgraph_query)
 OBSOLETE=gfa2gbwt
 
 .PHONY: all clean directories test

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -133,6 +133,7 @@ public:
 
   constexpr static size_t CHUNK_SIZE = 1024; // For parallel for_each_handle().
 
+  // TODO: This should be 0, as in GFA W-lines.
   constexpr static size_t NO_PHASE = std::numeric_limits<gbwt::PathName::path_name_type>::max();
 
   const static std::string EXTENSION; // ".gg"

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -1,9 +1,7 @@
 #ifndef GBWTGRAPH_INTERNAL_H
 #define GBWTGRAPH_INTERNAL_H
 
-#include <gbwt/gbwt.h>
-#include <gbwt/metadata.h>
-#include <gbwtgraph/utils.h>
+#include <gbwtgraph/gbz.h>
 
 #include <iostream>
 #include <string>
@@ -311,6 +309,13 @@ struct LargeRecordCache
   const gbwt::GBWT& index;
   std::unordered_map<gbwt::node_type, gbwt::DecompressedRecord> cache;
 };
+
+//------------------------------------------------------------------------------
+
+// Sample (sequence offset, GBWT position) at the start of a node approximately
+// every `sample_interval` bp, with the first sample at offset 0.
+// If `length` is not nullptr, it will be set to the length of the path.
+std::vector<std::pair<size_t, gbwt::edge_type>> sample_path_positions(const GBZ& gbz, path_handle_t path, size_t sample_interval, size_t* length = nullptr);
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -149,7 +149,10 @@ write_gfa_walk(
 {
   writer.put('W'); writer.newfield();
   writer.write(path_name.sample_name); writer.newfield();
-  writer.write(path_name.haplotype); writer.newfield();
+  // NOTE: It was a mistake to define NO_PHASE as unsigned -1.
+  // GFA uses 0, which is much more convenient.
+  size_t haplotype = (path_name.haplotype == GBWTGraph::NO_PHASE ? 0 : path_name.haplotype);
+  writer.write(haplotype); writer.newfield();
   writer.write(path_name.contig_name); writer.newfield();
   writer.write(path_name.offset); writer.newfield();
   writer.write(path_name.offset + length); writer.newfield();

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -73,7 +73,7 @@ public:
 */
 struct SubgraphQuery
 {
-  enum QueryType { path_offset_query, node_query };
+  enum QueryType { path_offset_query, path_interval_query, node_query, invalid_query };
 
   enum HaplotypeOutput { all_haplotypes, distinct_haplotypes, reference_only };
 
@@ -111,7 +111,6 @@ struct SubgraphQuery
 
 //------------------------------------------------------------------------------
 
-// FIXME tests
 /*
   A subgraph extracted from a GBZ graph using a `SubgraphQuery`. The subgraph
   is defined as the induced subgraph based on a stored set of node identifiers.

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -1,0 +1,162 @@
+#ifndef GBWTGRAPH_SUBGRAPH_H
+#define GBWTGRAPH_SUBGRAPH_H
+
+#include <gbwtgraph/gbz.h>
+
+#include <sdsl/sd_vector.hpp>
+
+#include <iostream>
+#include <set>
+#include <vector>
+
+/*
+  subgraph.h: Subgraph extraction from a GBZ graph as in GBZ-base.
+*/
+
+namespace gbwtgraph
+{
+
+//------------------------------------------------------------------------------
+
+// FIXME tests
+/*
+  A data structure for indexing reference and generic paths in a GBZ graph for
+  random access by sequence offset. For each path, the index stores GBWT
+  positions corresponding to node starts once every `sample_interval` bp
+  (default 1024 bp).
+*/
+class PathIndex
+{
+public:
+  // Sample node starts once every 1024 bp by default.
+  constexpr static size_t DEFAULT_SAMPLE_INTERVAL = 1024;
+
+  // Build the index for the paths in the given GBZ graph.
+  // The work is parallelized over the paths using OpenMP threads.
+  explicit PathIndex(const GBZ& gbz, size_t sample_interval = DEFAULT_SAMPLE_INTERVAL);
+
+  PathIndex(const PathIndex& source) = default;
+  PathIndex(PathIndex&& source) = default;
+  PathIndex& operator=(const PathIndex& source) = default;
+  PathIndex& operator=(PathIndex&& source) = default;
+
+  // For each `NamedPath` in the graph, mark the sampled sequence positions.
+  std::vector<sdsl::sd_vector<>> sequence_positions;
+
+  // Sampled GBWT positions for each `NamedPath` in the graph.
+  std::vector<std::vector<gbwt::edge_type>> gbwt_positions;
+
+  size_t paths() const { return this->sequence_positions.size(); }
+  size_t path_length(size_t path_id) const { return this->sequence_positions[path_id].size(); }
+
+  // Returns the last sampled position at or before `offset` in the path,
+  // as a pair (sequence offset, GBWT position). If there is no such path,
+  // returns (0, gbwt::invalid_edge()).
+  std::pair<size_t, gbwt::edge_type> sampled_position(size_t path_id, size_t offset) const;
+};
+
+//------------------------------------------------------------------------------
+
+// FIXME document
+struct SubgraphQuery
+{
+  enum QueryType { path_offset_query, node_query };
+
+  enum HaplotypeOutput { all_haplotypes, distinct_haplotypes, reference_only };
+
+  // Type of the query.
+  QueryType type;
+
+  // Which haplotypes to output.
+  HaplotypeOutput haplotype_output;
+
+  // Path handle for a reference or generic path.
+  path_handle_t path;
+
+  // Query offset on the path.
+  size_t offset;
+
+  // Node id for the node query.
+  nid_t node_id;
+
+  // Context length around the query position (in bp).
+  size_t context;
+
+  // Creates a subgraph query based on a path offset.
+  static SubgraphQuery path_offset(path_handle_t path, size_t offset, size_t context, HaplotypeOutput output);
+
+  // Creates a subgraph query based on a path interval [`from`, `to`).
+  // Throws `std::runtime_error` if the inteval is empty.
+  static SubgraphQuery path_interval(path_handle_t path, size_t from, size_t to, size_t context, HaplotypeOutput output);
+
+  // Creates a subgraph query based on a node id.
+  static SubgraphQuery node(nid_t node, size_t context, HaplotypeOutput output);
+
+  // Returns a string representation of the query.
+  std::string to_string(const GBZ& gbz) const;
+};
+
+//------------------------------------------------------------------------------
+
+// class Subgraph
+// FIXME implement, document, tests
+class Subgraph
+{
+public:
+  // Build a subgraph from the given query.
+  // If the query is based on a path, a path index must be provided.
+  // Throws `std::runtime_error` on error.
+  Subgraph(const GBZ& gbz, const PathIndex* path_index, const SubgraphQuery& query);
+
+  Subgraph(const Subgraph& source) = default;
+  Subgraph(Subgraph&& source) = default;
+  Subgraph& operator=(const Subgraph& source) = default;
+  Subgraph& operator=(Subgraph&& source) = default;
+
+  // Node identifiers in the subgraph.
+  std::set<nid_t> nodes;
+
+  // Paths in the subgraph (in canonical orientation).
+  std::vector<gbwt::vector_type> paths;
+
+  // Length of each path (in bp).
+  std::vector<size_t> path_lengths;
+
+  // Weight (the number of duplicates) of each path.
+  std::vector<size_t> path_weights;
+
+  // CIGAR string for each path relative to the reference path.
+  std::vector<std::string> path_cigars;
+
+  // Offset of the reference path in `paths`.
+  size_t reference_path;
+
+  // Handle for the reference path.
+  path_handle_t reference_handle;
+
+  // Starting offset of the reference path fragment in this subgraph.
+  // This is relative to the full path, ignoring any offset that may be stored
+  // in path metadata.
+  size_t reference_start;
+
+  // Convert the subgraph to GFA.
+  void to_gfa(const GBZ& gbz, std::ostream& out) const;
+
+private:
+  // Extract the paths within the subgraph and determine reference path information.
+  void extract_paths(const GBZ& gbz, size_t query_offset, const std::pair<pos_t, gbwt::edge_type>& ref_pos);
+
+  // Update the paths according to query type.
+  void update_paths(const SubgraphQuery& query);
+
+  gbwt::FullPathName reference_path_name(const GBZ& gbz) const;
+
+  const size_t* weight(size_t path_id) const;
+  const std::string* cigar(size_t path_id) const;
+};
+
+//------------------------------------------------------------------------------
+
+} // namespace gbwtgraph
+
+#endif // GBWTGRAPH_SUBGRAPH_H

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -18,12 +18,15 @@ namespace gbwtgraph
 
 //------------------------------------------------------------------------------
 
-// FIXME tests
 /*
   A data structure for indexing reference and generic paths in a GBZ graph for
   random access by sequence offset. For each path, the index stores GBWT
   positions corresponding to node starts once every `sample_interval` bp
   (default 1024 bp).
+
+  The index relies on the fact that path handles for generic / reference paths
+  in a GBWTGraph are integers in the range [0, n), where n is the number of such
+  paths in the graph.
 */
 class PathIndex
 {
@@ -47,17 +50,27 @@ public:
   std::vector<std::vector<gbwt::edge_type>> gbwt_positions;
 
   size_t paths() const { return this->sequence_positions.size(); }
-  size_t path_length(size_t path_id) const { return this->sequence_positions[path_id].size(); }
+  size_t path_length(path_handle_t handle) const { return this->sequence_positions[handlegraph::as_integer(handle)].size(); }
 
   // Returns the last sampled position at or before `offset` in the path,
   // as a pair (sequence offset, GBWT position). If there is no such path,
   // returns (0, gbwt::invalid_edge()).
-  std::pair<size_t, gbwt::edge_type> sampled_position(size_t path_id, size_t offset) const;
+  std::pair<size_t, gbwt::edge_type> sampled_position(path_handle_t handle, size_t offset) const;
 };
 
 //------------------------------------------------------------------------------
 
-// FIXME document
+/*
+  A query for extracting a subgraph from a GBZ graph. The subgraph contains all
+  nodes and edges within the given context (in bp) around a path offset, path
+  interval, or a node.
+
+  The query can also extract all path fragments within the subgraph. If the
+  query is based on a path, the corresponding fragment will have true metadata.
+  All other paths are reported as unknown paths. It is possible to output all
+  paths, only distinct paths (with the number of copies as the weight), or only
+  the reference path.
+*/
 struct SubgraphQuery
 {
   enum QueryType { path_offset_query, node_query };
@@ -98,8 +111,17 @@ struct SubgraphQuery
 
 //------------------------------------------------------------------------------
 
-// class Subgraph
-// FIXME document, tests
+// FIXME tests
+/*
+  A subgraph extracted from a GBZ graph using a `SubgraphQuery`. The subgraph
+  is defined as the induced subgraph based on a stored set of node identifiers.
+  There may be a defined reference path. There may be a weight (the number of
+  duplicates) for each path and a CIGAR string relative to the reference for
+  each non-reference path.
+
+  At the moment, the only supported functionality is converting the subgraph
+  to GFA format.
+*/
 class Subgraph
 {
 public:

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -99,7 +99,7 @@ struct SubgraphQuery
 //------------------------------------------------------------------------------
 
 // class Subgraph
-// FIXME implement, document, tests
+// FIXME document, tests
 class Subgraph
 {
 public:

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -166,7 +166,7 @@ public:
 
 private:
   // Extract the paths within the subgraph and determine reference path information.
-  void extract_paths(const GBZ& gbz, size_t query_offset, const std::pair<pos_t, gbwt::edge_type>& ref_pos);
+  void extract_paths(const GBZ& gbz, const SubgraphQuery& query, const std::pair<pos_t, gbwt::edge_type>& ref_pos);
 
   // Update the paths according to query type.
   void update_paths(const SubgraphQuery& query);

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -321,6 +321,22 @@ hash(const pos_t& pos)
 std::string reverse_complement(const std::string& seq);
 void reverse_complement_in_place(std::string& seq);
 
+/*
+  An edge is in canonical orientation, if:
+  1. The destination node has a higher identifier than the source node.
+  2. It is a self-loop with at least one end in forward orientation.
+*/
+bool edge_is_canonical(gbwt::node_type from, gbwt::node_type to);
+
+/*
+  A path is in canonical orientation, if:
+
+  1. It is empty.
+  2. Both the first and the last node are in forward orientation.
+  3. The edge from the first node to the last node would be in canonical orientation.
+*/
+bool path_is_canonical(const gbwt::vector_type& path);
+
 //------------------------------------------------------------------------------
 
 /*

--- a/src/gbz_stats.cpp
+++ b/src/gbz_stats.cpp
@@ -167,6 +167,7 @@ Config::Config(int argc, char** argv)
     { "node-visits", no_argument, 0, 'v' },
     { "record-bytes", no_argument, 0, 'b' },
     { "record-runs", no_argument, 0, 'r' },
+    { 0, 0, 0, 0 }
   };
 
   // Process options.

--- a/src/gfa2gbwt.cpp
+++ b/src/gfa2gbwt.cpp
@@ -238,6 +238,7 @@ Config::Config(int argc, char** argv)
     { "path-regex", required_argument, 0, 'r' },
     { "path-fields", required_argument, 0, 'f' },
     { "path-sense", required_argument, 0, OPT_PATH_SENSE },
+    { 0, 0, 0, 0 }
   };
 
   // Process options.

--- a/src/internal.cpp
+++ b/src/internal.cpp
@@ -255,4 +255,27 @@ LargeRecordCache::extract(gbwt::size_type sequence) const
 
 //------------------------------------------------------------------------------
 
+std::vector<std::pair<size_t, gbwt::edge_type>>
+sample_path_positions(const GBZ& gbz, path_handle_t path, size_t sample_interval, size_t* length)
+{
+  std::vector<std::pair<size_t, gbwt::edge_type>> result;
+  gbwt::size_type seq_id = gbwt::Path::encode(gbz.graph.handle_to_path(path), false);
+
+  size_t offset = 0, next_sample = 0;
+  for(gbwt::edge_type pos = gbz.index.start(seq_id); pos.first != gbwt::ENDMARKER; pos = gbz.index.LF(pos))
+  {
+    if(offset >= next_sample)
+    {
+      result.push_back({ offset, pos });
+      next_sample = offset + sample_interval;
+    }
+    offset += gbz.graph.get_length(GBWTGraph::node_to_handle(pos.first));
+  }
+  if(length != nullptr) { *length = offset; }
+
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
 } // namespace gbwtgraph

--- a/src/kmer_freq.cpp
+++ b/src/kmer_freq.cpp
@@ -177,7 +177,9 @@ Config::Config(int argc, char** argv)
     { "kmer-length", required_argument, 0, 'k' },
     { "save-memory", no_argument, 0, 's' },
     { "threads", required_argument, 0, 't' },
-    { "hash-tables", required_argument, 0, 'H' },  };
+    { "hash-tables", required_argument, 0, 'H' },
+    { 0, 0, 0, 0 }
+  };
 
   // Process options.
   while((c = getopt_long(argc, argv, "df:k:st:H:", long_options, &option_index)) != -1)

--- a/src/subgraph.cpp
+++ b/src/subgraph.cpp
@@ -1,0 +1,472 @@
+#include <gbwtgraph/subgraph.h>
+#include <gbwtgraph/internal.h>
+
+#include <sdsl/bit_vectors.hpp>
+
+#include <queue>
+#include <unordered_map>
+
+namespace gbwtgraph
+{
+
+//------------------------------------------------------------------------------
+
+// Numerical class constants.
+constexpr size_t PathIndex::DEFAULT_SAMPLE_INTERVAL;
+
+//------------------------------------------------------------------------------
+
+PathIndex::PathIndex(const GBZ& gbz, size_t sample_interval) :
+  sequence_positions(gbz.graph.named_paths.size()), gbwt_positions(gbz.graph.named_paths.size())
+{
+  #pragma omp parallel for schedule(dynamic, 1)
+  for(size_t i = 0; i < gbz.graph.named_paths.size(); i++)
+  {
+    const NamedPath& path = gbz.graph.named_paths[i];
+
+    size_t offset = 0, next_sample = 0;
+    std::vector<size_t> seq_pos;
+    std::vector<gbwt::edge_type>& gbwt_pos = this->gbwt_positions[i];
+    for(gbwt::edge_type pos = path.from; pos.first != gbwt::ENDMARKER; pos = gbz.index.LF(pos))
+    {
+      if(offset >= next_sample)
+      {
+        seq_pos.push_back(offset);
+        gbwt_pos.push_back(pos);
+        next_sample = offset + sample_interval;
+      }
+      offset += gbz.graph.get_length(GBWTGraph::node_to_handle(pos.first));
+    }
+
+    sdsl::sd_vector_builder builder(offset, seq_pos.size());
+    for(size_t pos : seq_pos) { builder.set_unsafe(pos); }
+    this->sequence_positions[i] = sdsl::sd_vector<>(builder);
+  }
+}
+
+std::pair<size_t, gbwt::edge_type>
+PathIndex::sampled_position(size_t path_id, size_t offset) const
+{
+  if(path_id >= this->paths()) { return std::make_pair(0, gbwt::invalid_edge()); }
+  auto iter = this->sequence_positions[path_id].predecessor(offset);
+  if(iter == this->sequence_positions[path_id].one_end()) { return std::make_pair(0, gbwt::invalid_edge()); }
+  return std::make_pair(iter->second, this->gbwt_positions[path_id][iter->first]);
+}
+
+//------------------------------------------------------------------------------
+
+SubgraphQuery
+SubgraphQuery::path_offset(path_handle_t path, size_t offset, size_t context, HaplotypeOutput output)
+{
+  SubgraphQuery result
+  {
+    QueryType::path_offset_query, output,
+    path, offset,
+    0,
+    context
+  };
+  return result;
+}
+
+SubgraphQuery
+SubgraphQuery::path_interval(path_handle_t path, size_t from, size_t to, size_t context, HaplotypeOutput output)
+{
+  if(from >= to)
+  {
+    std::string msg = "SubgraphQuery::path_interval(): Empty interval [" + std::to_string(from) + ", " + std::to_string(to) + ")";
+    throw std::runtime_error(msg);
+  }
+  size_t offset = from + (to - from) / 2;
+
+  SubgraphQuery result
+  {
+    QueryType::path_offset_query, output,
+    path, offset,
+    0,
+    context
+  };
+  return result;
+}
+
+SubgraphQuery
+SubgraphQuery::node(nid_t node, size_t context, HaplotypeOutput output)
+{
+  SubgraphQuery result
+  {
+    QueryType::node_query, output,
+    handlegraph::as_path_handle(std::numeric_limits<size_t>::max()), 0,
+    node,
+    context
+  };
+  return result;
+}
+
+std::string
+output_type(SubgraphQuery::HaplotypeOutput output)
+{
+  switch(output)
+  {
+  case SubgraphQuery::HaplotypeOutput::all_haplotypes: return "all";
+  case SubgraphQuery::HaplotypeOutput::distinct_haplotypes: return "distinct";
+  case SubgraphQuery::HaplotypeOutput::reference_only: return "reference only";
+  default: return "invalid output";
+  }
+}
+
+std::string
+SubgraphQuery::to_string(const GBZ& gbz) const
+{
+  if(this->type == QueryType::path_offset_query)
+  {
+    std::string path_name = gbz.graph.get_path_name(this->path);
+    std::string output = output_type(this->haplotype_output);
+    return "(path " + path_name + ", offset " + std::to_string(this->offset) + ", context " + std::to_string(this->context) + ", " + output + ")";
+  }
+  else if(this->type == QueryType::node_query)
+  {
+    std::string output = output_type(this->haplotype_output);
+    return "(node " + std::to_string(this->node_id) + ", context " + std::to_string(this->context) + ", " + output + ")";
+  }
+  else
+  {
+    return "(invalid query)";
+  }
+}
+
+//------------------------------------------------------------------------------
+
+std::pair<pos_t, gbwt::edge_type>
+find_position(const GBZ& gbz, const PathIndex& path_index, const SubgraphQuery& query)
+{
+  std::pair<size_t, gbwt::edge_type> position = path_index.sampled_position(handlegraph::as_integer(query.path), query.offset);
+  if(position.second == gbwt::invalid_edge())
+  {
+    std::string msg = "Subgraph::Subgraph(): Could not find an indexed path position for query " + std::to_string(query.offset);
+    throw std::runtime_error(msg);
+  }
+
+  while(true)
+  {
+    size_t node_len = gbz.graph.get_length(GBWTGraph::node_to_handle(position.second.first));
+    if(position.first + node_len > query.offset)
+    {
+      pos_t graph_pos = make_pos_t(gbwt::Node::id(position.second.first), gbwt::Node::is_reverse(position.second.first), query.offset - position.first);
+      return std::make_pair(graph_pos, position.second);
+    }
+    position.first += node_len;
+    position.second = gbz.index.LF(position.second);
+    if(position.second == gbwt::invalid_edge())
+    {
+      std::string msg = "Subgraph::Subgraph(): Path " + gbz.graph.get_path_name(query.path) + " does not contain offset " + std::to_string(query.offset);
+      throw std::runtime_error(msg);
+    }
+  }
+}
+
+std::set<nid_t>
+find_subgraph(const GBWTGraph& graph, pos_t position, size_t context)
+{
+  std::set<nid_t> result;
+  result.insert(id(position));
+
+  struct Comparator
+  {
+    bool operator()(const std::pair<size_t, pos_t>& a, const std::pair<size_t, pos_t>& b) const
+    {
+      return a.first > b.first;
+    }
+  };
+
+  // (distance, position)
+  std::priority_queue<std::pair<size_t, pos_t>, std::vector<std::pair<size_t, pos_t>>, Comparator> queue;
+  queue.push(std::make_pair(0, position));
+
+  while(!queue.empty())
+  {
+    std::pair<size_t, pos_t> current = queue.top(); queue.pop();
+    if(result.find(id(current.second)) != result.end()) { continue; }
+    for(bool is_reverse : { false, true })
+    {
+      handle_t handle = graph.get_handle(id(current.second), is_reverse);
+      size_t distance = current.first;
+      if(is_reverse == is_rev(current.second)) { distance += graph.get_length(handle) - offset(current.second); }
+      else { distance += offset(current.second) + 1; }
+      if(distance <= context)
+      {
+        graph.follow_edges(handle, false, [&](const handle_t& next)
+        {
+          queue.push(std::make_pair(distance, make_pos_t(graph.get_id(next), graph.get_is_reverse(next), 0)));
+        });
+      }
+      result.insert(id(current.second));
+    }
+  }
+
+  return result;
+}
+
+void
+Subgraph::extract_paths(const GBZ& gbz, size_t query_offset, const std::pair<pos_t, gbwt::edge_type>& ref_pos)
+{
+  const GBWTGraph& graph = gbz.graph;
+  const gbwt::GBWT& index = gbz.index;
+
+  // For each GBWT node in the subgraph, mark which GBWT offsets have a
+  // predecessor in the subgraph.
+  std::unordered_map<gbwt::node_type, sdsl::bit_vector> has_predecessor;
+  has_predecessor.reserve(this->nodes.size() * 2);
+  for(nid_t node : this->nodes)
+  {
+    for(bool is_reverse : { false, true })
+    {
+      gbwt::node_type gbwt_node = gbwt::Node::encode(node, is_reverse);
+      gbwt::CompressedRecord record = index.record(gbwt_node);
+      has_predecessor[gbwt_node] = sdsl::bit_vector(record.size(), 0);
+    }
+  }
+
+  // Mark the positions that have predecessors in the subgraph.
+  for(nid_t node : this->nodes)
+  {
+    for(bool is_reverse : { false, true })
+    {
+      gbwt::node_type gbwt_node = gbwt::Node::encode(node, is_reverse);
+      gbwt::CompressedRecord record = index.record(gbwt_node);
+      gbwt::DecompressedRecord decompressed(record);
+      for(size_t i = 0; i < decompressed.size(); i++)
+      {
+        gbwt::edge_type successor = decompressed.LF(i);
+        auto iter = has_predecessor.find(successor.first);
+        if(iter != has_predecessor.end())
+        {
+          iter->second[successor.second] = true;
+        }
+      }
+    }
+  }
+
+  // FIXME: If the GBWT index is invalid, we could have infinite loops.
+  // Extract all paths and determine reference path information if necessary.
+  for(const auto& start_node : has_predecessor)
+  {
+    for(size_t gbwt_offset = 0; gbwt_offset < start_node.second.size(); gbwt_offset++)
+    {
+      if(start_node.second[gbwt_offset]) { continue; } // There is a predecessor.
+      gbwt::edge_type curr(start_node.first, gbwt_offset);
+      bool is_ref = false;
+      gbwt::vector_type path;
+      size_t path_length = 0;
+      while(curr.first != gbwt::ENDMARKER)
+      {
+        if(curr == ref_pos.second)
+        {
+          this->reference_path = this->paths.size();
+          this->reference_start = query_offset - path_length - offset(ref_pos.first);
+          is_ref = true;
+        }
+        path.push_back(curr.first);
+        path_length += graph.get_length(GBWTGraph::node_to_handle(curr.first));
+        curr = index.LF(curr);
+      }
+      if(is_ref)
+      {
+        if(!path_is_canonical(path))
+        {
+          // TODO: Do we want this?
+          std::cerr << "Subgraph::Subgraph(): Warning: Reference path is not in canonical orientation" << std::endl;
+        }
+        this->paths.push_back(path);
+        this->path_lengths.push_back(path_length);
+      }
+      else if(path_is_canonical(path))
+      {
+        this->paths.push_back(path);
+        this->path_lengths.push_back(path_length);
+      }
+    }
+  }
+
+  if(ref_pos.second != gbwt::invalid_edge() && this->reference_path == std::numeric_limits<size_t>::max())
+  {
+    std::string msg = "Subgraph::Subgraph(): Reference path not found in the subgraph";
+    throw std::runtime_error(msg);
+  }
+}
+
+void
+Subgraph::update_paths(const SubgraphQuery& query)
+{
+  if(query.haplotype_output == SubgraphQuery::HaplotypeOutput::all_haplotypes) { return; }
+
+  if(query.haplotype_output == SubgraphQuery::HaplotypeOutput::reference_only)
+  {
+    std::vector<gbwt::vector_type> new_paths { this->paths[this->reference_path] };
+    this->paths.swap(new_paths);
+    this->reference_path = 0;
+    return;
+  }
+
+  // TODO: This could be more efficient by using normal GBWT operations.
+  if(query.haplotype_output == SubgraphQuery::HaplotypeOutput::distinct_haplotypes)
+  {
+    gbwt::vector_type ref_path = this->paths[this->reference_path];
+    std::sort(this->paths.begin(), this->paths.end());
+    std::vector<gbwt::vector_type> new_paths;
+    std::vector<size_t> new_lengths;
+    for(size_t i = 0; i < this->paths.size(); i++)
+    {
+      const gbwt::vector_type& path = this->paths[i];
+      if(new_paths.empty() || path != new_paths.back())
+      {
+        if(path == ref_path) { this->reference_path = new_paths.size(); }
+        new_paths.push_back(path);
+        new_lengths.push_back(this->path_lengths[i]);
+        this->path_weights.push_back(1);
+      }
+      else { this->path_weights.back()++; }
+    }
+    this->paths.swap(new_paths);
+    this->path_lengths.swap(new_lengths);
+  }
+}
+
+Subgraph::Subgraph(const GBZ& gbz, const PathIndex* path_index, const SubgraphQuery& query) :
+  reference_path(std::numeric_limits<size_t>::max()),
+  reference_handle(handlegraph::as_path_handle(std::numeric_limits<size_t>::max())),
+  reference_start(0)
+{
+  std::pair<pos_t, gbwt::edge_type> position;
+  size_t context = query.context;
+
+  switch(query.type)
+  {
+  case SubgraphQuery::QueryType::path_offset_query:
+    {
+      if(path_index == nullptr)
+      {
+        throw std::runtime_error("Subgraph::Subgraph(): Path index required for path queries");
+      }
+      position = find_position(gbz, *path_index, query);
+      this->reference_handle = query.path;
+      break;
+    }
+  case SubgraphQuery::QueryType::node_query:
+    {
+      // TODO: This has the same issue as in GBZ-base. If node length is even,
+      // the right context is one bp too long. What about odd lengths?
+      size_t node_len = gbz.graph.get_length(gbz.graph.get_handle(query.node_id));
+      position.first = make_pos_t(query.node_id, false, node_len / 2);
+      position.second = gbwt::invalid_edge();
+      context += node_len / 2;
+      break;
+    }
+  default:
+    {
+      throw std::runtime_error("Subgraph::Subgraph(): Invalid query type");
+    }
+  }
+
+  this->nodes = find_subgraph(gbz.graph, position.first, context);
+  this->extract_paths(gbz, query.offset, position);
+  this->update_paths(query);
+
+  // FIXME: compute CIGAR strings for non-reference paths
+}
+
+//------------------------------------------------------------------------------
+
+gbwt::FullPathName
+Subgraph::reference_path_name(const GBZ& gbz) const
+{
+  gbwt::size_type path_id = gbz.graph.handle_to_path(this->reference_handle);
+  gbwt::FullPathName path_name = gbz.index.metadata.full_path(path_id);
+  path_name.offset = this->reference_start;
+  return path_name;
+}
+
+const size_t*
+Subgraph::weight(size_t path_id) const
+{
+  if(path_id >= this->path_weights.size()) { return nullptr; }
+  return &(this->path_weights[path_id]);
+}
+
+const std::string*
+Subgraph::cigar(size_t path_id) const
+{
+  if(path_id >= this->path_cigars.size()) { return nullptr; }
+  return &(this->path_cigars[path_id]);
+}
+
+void
+Subgraph::to_gfa(const GBZ& gbz, std::ostream& out) const
+{
+  TSVWriter writer(out);
+
+  // GFA header.
+  if(this->reference_path < this->paths.size())
+  {
+    std::string sample_name = gbz.graph.get_sample_name(this->reference_handle);
+    write_gfa_header(writer, &sample_name);
+  }
+  else { write_gfa_header(writer, nullptr); }
+
+  // Nodes / segments.
+  for(nid_t node : this->nodes)
+  {
+    handle_t handle = gbz.graph.get_handle(node);
+    write_gfa_segment(writer, node, gbz.graph.get_sequence_view(handle));
+  }
+
+  // Edges / links.
+  for(nid_t node : this->nodes)
+  {
+    for(bool is_reverse : { false, true })
+    {
+      gbwt::node_type from = gbwt::Node::encode(node, is_reverse);
+      handle_t handle = GBWTGraph::node_to_handle(from);
+      gbz.graph.follow_edges(handle, false, [&](const handle_t& next)
+      {
+        gbwt::node_type to = GBWTGraph::handle_to_node(next);
+        nid_t successor = gbwt::Node::id(to);
+        if(this->nodes.find(successor) != this->nodes.end() && edge_is_canonical(from, to))
+        {
+          write_gfa_link(writer, from, to);
+        }
+      });
+    }
+  }
+
+  // W-lines: reference path
+  std::string contig_name = "unknown";
+  if(this->reference_path < this->paths.size())
+  {
+    const gbwt::vector_type& path = this->paths[this->reference_path];
+    gbwt::FullPathName path_name = this->reference_path_name(gbz);
+    contig_name = path_name.contig_name;
+    size_t length = this->path_lengths[this->reference_path];
+    const size_t* weight = this->weight(this->reference_path);
+    const std::string* cigar = this->cigar(this->reference_path);
+    write_gfa_walk(writer, path, path_name, length, weight, cigar);
+  }
+
+  // W-lines: anonymous haplotypes
+  size_t haplotype_id = 1;
+  for(size_t i = 0; i < this->paths.size(); i++)
+  {
+    if(i == this->reference_path) { continue; }
+    const gbwt::vector_type& path = this->paths[i];
+    gbwt::FullPathName path_name { "unknown", contig_name, haplotype_id, 0 };
+    size_t length = this->path_lengths[i];
+    const size_t* weight = this->weight(i);
+    const std::string* cigar = this->cigar(i);
+    write_gfa_walk(writer, path, path_name, length, weight, cigar);
+    haplotype_id++;
+  }
+
+  writer.flush();
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace gbwtgraph

--- a/src/subgraph_query.cpp
+++ b/src/subgraph_query.cpp
@@ -1,0 +1,228 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <getopt.h>
+
+#include <gbwtgraph/gbz.h>
+#include <gbwtgraph/subgraph.h>
+
+using namespace gbwtgraph;
+
+//------------------------------------------------------------------------------
+
+const std::string tool_name = "Subgraph Query";
+
+struct Config
+{
+  Config(int argc, char** argv);
+
+  std::string graph_file;
+
+  SubgraphQuery::QueryType query_type = SubgraphQuery::QueryType::invalid_query;
+  SubgraphQuery::HaplotypeOutput haplotype_output = SubgraphQuery::HaplotypeOutput::all_haplotypes;
+
+  std::string sample_name = REFERENCE_PATH_SAMPLE_NAME, contig_name = "";
+
+  size_t offset = 0, limit = 0;
+  nid_t node_id = 0;
+  size_t context = 100;
+};
+
+std::unique_ptr<PathIndex> create_path_index(const GBZ& gbz, const SubgraphQuery& query)
+{
+  if(query.type == SubgraphQuery::QueryType::path_offset_query || query.type == SubgraphQuery::QueryType::path_interval_query)
+  {
+    return std::make_unique<PathIndex>(gbz);
+  }
+  return nullptr;
+}
+
+path_handle_t find_reference_path(const GBZ& gbz, const Config& config)
+{
+  const gbwt::Metadata& metadata = gbz.index.metadata;
+  std::vector<gbwt::size_type> path_ids = metadata.findPaths(metadata.sample(config.sample_name), metadata.contig(config.contig_name));
+  if(path_ids.size() != 1)
+  {
+    std::string msg = "Found " + std::to_string(path_ids.size()) + " reference paths for sample " + config.sample_name + ", contig " + config.contig_name;
+    throw std::runtime_error(msg);
+  }
+  return gbz.graph.path_to_handle(path_ids.front());
+}
+
+SubgraphQuery create_query(const GBZ& gbz, const Config& config)
+{
+  switch(config.query_type)
+  {
+  case SubgraphQuery::QueryType::path_offset_query:
+    {
+      path_handle_t path = find_reference_path(gbz, config);
+      return SubgraphQuery::path_offset(path, config.offset, config.context, config.haplotype_output);
+    }
+  case SubgraphQuery::QueryType::path_interval_query:
+    {
+      path_handle_t path = find_reference_path(gbz, config);
+      return SubgraphQuery::path_interval(path, config.offset, config.limit, config.context, config.haplotype_output);
+    }
+  case SubgraphQuery::QueryType::node_query:
+    return SubgraphQuery::node(config.node_id, config.context, config.haplotype_output);
+  default:
+    throw std::runtime_error("Unknown query type");
+  }
+}
+
+//------------------------------------------------------------------------------
+
+int
+main(int argc, char** argv)
+{
+  double start = gbwt::readTimer();
+
+  try
+  {
+    Config config(argc, argv);
+
+    GBZ gbz;
+    sdsl::simple_sds::load_from(gbz, config.graph_file);
+    SubgraphQuery query = create_query(gbz, config);
+    std::unique_ptr<PathIndex> path_index = create_path_index(gbz, query);
+
+    Subgraph subgraph(gbz, path_index.get(), query);
+    subgraph.to_gfa(gbz, std::cout);
+    std::cout.flush();
+  }
+  catch(const std::runtime_error& e)
+  {
+    std::cerr << "subgraph_query: " << e.what() << std::endl;
+  }
+
+  double seconds = gbwt::readTimer() - start;
+  std::cerr << "Used " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void
+printUsage(int exit_code)
+{
+  Version::print(std::cerr, tool_name);
+
+  std::cerr << "Usage: subgraph_query [options] graph.gbz" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "Options:" << std::endl;
+  std::cerr << "  --sample NAME     sample name for the reference path (default: no sample name)" << std::endl;
+  std::cerr << "  --contig NAME     contig name for the reference path (required for --offset and --interval)" << std::endl;
+  std::cerr << "  --offset N        query a reference path at offset N" << std::endl;
+  std::cerr << "  --interval M..N   query a reference path in interval [M, N)" << std::endl;
+  std::cerr << "  --node N          query a node with id N" << std::endl;
+  std::cerr << "  --context N       context length around the query position in bp (default: 100)" << std::endl;
+  std::cerr << "  --distinct        output distinct haplotypes only" << std::endl;
+  std::cerr << "  --reference-only  only output the reference path" << std::endl;
+  std::cerr << std::endl;
+
+  std::exit(exit_code);
+}
+
+//------------------------------------------------------------------------------
+
+Config::Config(int argc, char** argv)
+{
+  if(argc < 2) { printUsage(EXIT_SUCCESS); }
+
+  constexpr int OPT_SAMPLE = 1000;
+  constexpr int OPT_CONTIG = 1001;
+  constexpr int OPT_OFFSET = 1002;
+  constexpr int OPT_INTERVAL = 1003;
+  constexpr int OPT_NODE = 1004;
+  constexpr int OPT_CONTEXT = 1005;
+  constexpr int OPT_DISTINCT = 1006;
+  constexpr int OPT_REFERENCE_ONLY = 1007;
+
+  // Data for `getopt_long()`.
+  int c = 0, option_index = 0;
+  option long_options[] =
+  {
+    { "sample", required_argument, 0, OPT_SAMPLE },
+    { "contig", required_argument, 0, OPT_CONTIG },
+    { "offset", required_argument, 0, OPT_OFFSET },
+    { "interval", required_argument, 0, OPT_INTERVAL },
+    { "node", required_argument, 0, OPT_NODE },
+    { "context", required_argument, 0, OPT_CONTEXT },
+    { "distinct", no_argument, 0, OPT_DISTINCT },
+    { "reference-only", no_argument, 0, OPT_REFERENCE_ONLY },
+    { 0, 0, 0, 0 }
+  };
+
+  // Process options.
+  while((c = getopt_long(argc, argv, "", long_options, &option_index)) != -1)
+  {
+    switch(c)
+    {
+    case OPT_SAMPLE:
+      this->sample_name = optarg;
+      break;
+    case OPT_CONTIG:
+      this->contig_name = optarg;
+      break;
+    case OPT_OFFSET:
+      this->query_type = SubgraphQuery::QueryType::path_offset_query;
+      this->offset = std::stoul(optarg);
+      break;
+    case OPT_INTERVAL:
+      this->query_type = SubgraphQuery::QueryType::path_interval_query;
+      {
+        std::string interval(optarg);
+        size_t pos = interval.find("..");
+        if(pos == std::string::npos)
+        {
+          std::string msg = "Invalid path interval: " + interval;
+          throw std::runtime_error(msg);
+        }
+        this->offset = std::stoul(interval.substr(0, pos));
+        this->limit = std::stoul(interval.substr(pos + 2));
+      }
+      break;
+    case OPT_NODE:
+      this->query_type = SubgraphQuery::QueryType::node_query;
+      this->node_id = std::stoul(optarg);
+      break;
+    case OPT_CONTEXT:
+      this->context = std::stoul(optarg);
+      break;
+    case OPT_DISTINCT:
+      this->haplotype_output = SubgraphQuery::HaplotypeOutput::distinct_haplotypes;
+      break;
+    case OPT_REFERENCE_ONLY:
+      this->haplotype_output = SubgraphQuery::HaplotypeOutput::reference_only;
+      break;
+
+    case '?':
+      std::exit(EXIT_FAILURE);
+    default:
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  // Sanity checks.
+  if(optind >= argc)
+  {
+    std::string msg = "Missing graph file";
+    throw std::runtime_error(msg);
+  }
+  this->graph_file = argv[optind]; optind++;
+  if(this->query_type == SubgraphQuery::QueryType::invalid_query)
+  {
+    std::string msg = "Path offset or interval or node id is required";
+    throw std::runtime_error(msg);
+  }
+  if((this->query_type == SubgraphQuery::QueryType::path_offset_query || this->query_type == SubgraphQuery::QueryType::path_interval_query) && this->contig_name.empty())
+  {
+    std::string msg = "Contig name is required for path offset or interval";
+    throw std::runtime_error(msg);
+  }
+}
+
+//------------------------------------------------------------------------------

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -408,6 +408,23 @@ reverse_complement_in_place(std::string& seq)
   }
 }
 
+bool edge_is_canonical(gbwt::node_type from, gbwt::node_type to)
+{
+  nid_t from_id = gbwt::Node::id(from), to_id = gbwt::Node::id(to);
+  if(!gbwt::Node::is_reverse(from)) { return (to_id >= from_id); }
+  else
+  {
+    return ((to_id > from_id) || ((to_id == from_id) && !gbwt::Node::is_reverse(to)));
+  }
+}
+
+bool path_is_canonical(const gbwt::vector_type& path)
+{
+  if(path.empty()) { return true; }
+  if(!gbwt::Node::is_reverse(path.front()) && !gbwt::Node::is_reverse(path.back())) { return true; }
+  return edge_is_canonical(path.front(), path.back());
+}
+
 //------------------------------------------------------------------------------
 
 void

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -421,7 +421,7 @@ bool edge_is_canonical(gbwt::node_type from, gbwt::node_type to)
 bool path_is_canonical(const gbwt::vector_type& path)
 {
   if(path.empty()) { return true; }
-  if(!gbwt::Node::is_reverse(path.front()) && !gbwt::Node::is_reverse(path.back())) { return true; }
+  if(gbwt::Node::is_reverse(path.front()) == gbwt::Node::is_reverse(path.back())) { return !gbwt::Node::is_reverse(path.front()); }
   return edge_is_canonical(path.front(), path.back());
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -39,7 +39,7 @@ endif
 CXX_FLAGS=$(MY_CXX_FLAGS) $(PARALLEL_FLAGS) $(MY_CXX_OPT_FLAGS) -I$(MAIN_DIR)/include -I$(INC_DIR)
 
 HEADERS=$(wildcard $(GBWT_DIR)/include/gbwt/*.h) shared.h
-PROGRAMS=test_utils test_gbwtgraph test_cached_gbwtgraph test_gfa test_gbz test_minimizer test_index test_algorithms test_path_cover
+PROGRAMS=test_utils test_gbwtgraph test_cached_gbwtgraph test_gfa test_gbz test_minimizer test_index test_algorithms test_path_cover test_subgraph
 
 .PHONY: all clean test
 all:$(PROGRAMS)

--- a/tests/test_subgraph.cpp
+++ b/tests/test_subgraph.cpp
@@ -1,0 +1,398 @@
+#include <gtest/gtest.h>
+
+#include <gbwtgraph/subgraph.h>
+#include <gbwtgraph/gfa.h>
+#include <gbwtgraph/internal.h>
+
+#include "shared.h"
+
+using namespace gbwtgraph;
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+
+GBZ
+build_gbz(const std::string& graph_name)
+{
+  auto parse = gfa_to_gbwt(graph_name);
+  return GBZ(parse.first, parse.second);
+}
+
+//------------------------------------------------------------------------------
+
+class PathIndexTest : public ::testing::Test
+{
+public:
+  std::vector<std::string> graphs;
+  std::vector<std::vector<size_t>> indexed_path_lengths;
+
+  PathIndexTest()
+  {
+    this->graphs = { "gfas/default.gfa", "gfas/components_ref.gfa" };
+    this->indexed_path_lengths =
+    {
+      { 5, 4 },
+      { 5, 5 }
+    };
+  }
+};
+
+TEST_F(PathIndexTest, BuildIndex)
+{
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    PathIndex index(gbz);
+    ASSERT_EQ(index.paths(), this->indexed_path_lengths[i].size()) << "Invalid number of indexed paths for graph " << this->graphs[i];
+    for(size_t j = 0; j < this->indexed_path_lengths[i].size(); j++)
+    {
+      path_handle_t handle = handlegraph::as_path_handle(j);
+      EXPECT_EQ(index.path_length(handle), this->indexed_path_lengths[i][j]) << "Invalid length of path " << j << " for graph " << this->graphs[i];
+    }
+  }
+}
+
+TEST_F(PathIndexTest, IndexedPaths)
+{
+  for(auto& graph_name : this->graphs)
+  {
+    GBZ gbz = build_gbz(graph_name);
+    for(size_t interval = 0; interval < 10; interval++)
+    {
+      PathIndex index(gbz, interval);
+      for(size_t path_id = 0; path_id < index.paths(); path_id++)
+      {
+        size_t length = 0;
+        path_handle_t handle = handlegraph::as_path_handle(path_id);
+        std::vector<std::pair<size_t, gbwt::edge_type>> reference_positions = sample_path_positions(gbz, handle, interval, &length);
+        size_t pos_offset = 0;
+        for(size_t seq_offset = 0; seq_offset <= length; seq_offset++)
+        {
+          auto position = index.sampled_position(handle, seq_offset);
+          if(pos_offset + 1 < reference_positions.size() && reference_positions[pos_offset + 1].first <= seq_offset) { pos_offset++; }
+          ASSERT_EQ(position, reference_positions[pos_offset]) << "Invalid sampled position for path " << path_id << ", offset " << seq_offset << " in graph " << graph_name;
+        }
+      }
+    }
+  }
+}
+
+TEST_F(PathIndexTest, NonIndexedPaths)
+{
+  for(auto& graph_name : this->graphs)
+  {
+    GBZ gbz = build_gbz(graph_name);
+    for(size_t interval = 0; interval < 10; interval++)
+    {
+      PathIndex index(gbz, interval);
+      for(size_t path_id = index.paths(); path_id < gbz.index.metadata.paths(); path_id++)
+      {
+        path_handle_t handle = handlegraph::as_path_handle(path_id);
+        for(size_t seq_offset = 0; seq_offset <= 10; seq_offset++)
+        {
+          auto position = index.sampled_position(handle, seq_offset);
+          ASSERT_EQ(position.second, gbwt::invalid_edge()) << "Found a sampled position for non-indexed path " << path_id << ", offset " << seq_offset << " in graph " << graph_name;
+        }
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+
+class SubgraphQueryTest : public ::testing::Test
+{
+public:
+  std::vector<std::string> graphs;
+  std::vector<std::string> reference_samples;
+
+  SubgraphQueryTest()
+  {
+    this->graphs = { "gfas/default.gfa", "gfas/components_ref.gfa" };
+    this->reference_samples = { REFERENCE_PATH_SAMPLE_NAME, "ref" };
+  }
+
+  void find_path(const GBZ& gbz, size_t graph_number, const std::string& contig_name, path_handle_t& out) const
+  {
+    const gbwt::Metadata& metadata = gbz.index.metadata;
+    std::vector<gbwt::size_type> path_ids = metadata.findPaths(metadata.sample(this->reference_samples[graph_number]), metadata.contig(contig_name));
+    ASSERT_EQ(path_ids.size(), size_t(1)) << "Found " << path_ids.size() << " reference paths for contig " << contig_name << " in graph " << this->graphs[graph_number];
+    out = gbz.graph.path_to_handle(path_ids.front());
+  }
+
+  Subgraph find_subgraph(const GBZ& gbz, const SubgraphQuery& query) const
+  {
+    PathIndex index(gbz);
+    return Subgraph(gbz, &index, query);
+  }
+
+  void check_subgraph(const GBZ& gbz, size_t graph_number, const Subgraph& subgraph, const SubgraphQuery& query, const std::set<nid_t>& nodes, size_t path_count) const
+  {
+    ASSERT_EQ(subgraph.nodes.size(), nodes.size()) << "Invalid number of nodes for query " << query.to_string(gbz) << " in graph " << this->graphs[graph_number];
+    for(nid_t node : nodes)
+    {
+      EXPECT_TRUE(subgraph.nodes.find(node) != subgraph.nodes.end()) << "Node " << node << " not found by query " << query.to_string(gbz) << " in graph " << this->graphs[graph_number];
+    }
+    ASSERT_EQ(subgraph.paths.size(), path_count) << "Invalid number of paths for query " << query.to_string(gbz) << " in graph " << this->graphs[graph_number];
+  }
+
+  void check_gfa(const GBZ& gbz, size_t graph_number, const Subgraph& subgraph, const SubgraphQuery& query, const std::vector<std::string>& gfa) const
+  {
+    std::ostringstream out;
+    subgraph.to_gfa(gbz, out);
+    std::string result = out.str();
+    std::istringstream stream(result);
+    std::vector<std::string> lines;
+    std::string line;
+    while(std::getline(stream, line)) { lines.push_back(line); }
+
+    ASSERT_EQ(lines.size(), gfa.size()) << "Invalid number of lines in GFA output for query " << query.to_string(gbz) << " in graph " << this->graphs[graph_number];
+    for(size_t i = 0; i < lines.size(); i++)
+    {
+      EXPECT_EQ(lines[i], gfa[i]) << "Invalid GFA line " << i << " for query " << query.to_string(gbz) << " in graph " << this->graphs[graph_number];
+    }
+  }
+};
+
+TEST_F(SubgraphQueryTest, AllHaplotypes)
+{
+  // All haplotypes within 1 bp of contig A, offset 2.
+  std::string contig_name = "A";
+  size_t offset = 2, context = 1;
+  std::set<nid_t> nodes { 12, 13, 14, 15, 16 };
+  size_t path_count = 3;
+
+  std::vector<std::string> gfa
+  {
+    "H\tVN:Z:1.1\tRS:Z:", // Append reference sample to line 0.
+    "S\t12\tA",
+    "S\t13\tT",
+    "S\t14\tT",
+    "S\t15\tA",
+    "S\t16\tC",
+    "L\t12\t+\t14\t+\t0M",
+    "L\t13\t+\t14\t+\t0M",
+    "L\t14\t+\t15\t+\t0M",
+    "L\t14\t+\t16\t+\t0M",
+    "", // Set reference path manually on line 10.
+    "W\tunknown\t1\tA\t0\t3\t>12>14>15\tCG:Z:3M", 
+    "W\tunknown\t2\tA\t0\t3\t>13>14>16\tCG:Z:3M", 
+  };
+  std::vector<std::string> reference_paths
+  {
+    "W\t" + this->reference_samples[0] + "\t0\tA\t1\t4\t>12>14>15",
+    "W\t" + this->reference_samples[1] + "\t0\tA\t1\t4\t>13>14>15",
+  };
+
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    path_handle_t ref_path;
+    this->find_path(gbz, i, contig_name, ref_path);
+    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::all_haplotypes);
+    Subgraph subgraph = this->find_subgraph(gbz, query);
+    this->check_subgraph(gbz, i, subgraph, query, nodes, path_count);
+
+    std::vector<std::string> true_gfa = gfa;
+    true_gfa[0] += this->reference_samples[i];
+    true_gfa[10] = reference_paths[i];
+    this->check_gfa(gbz, i, subgraph, query, true_gfa);
+  }
+}
+
+TEST_F(SubgraphQueryTest, DistinctHaplotypes)
+{
+  // Distinct haplotypes within 1 bp of contig A, offset 2.
+  std::string contig_name = "A";
+  size_t offset = 2, context = 1;
+  std::set<nid_t> nodes { 12, 13, 14, 15, 16 };
+  std::vector<size_t> path_counts { 2, 3 };
+
+  std::vector<std::string> gfa
+  {
+    "H\tVN:Z:1.1\tRS:Z:", // Append reference sample to line 0.
+    "S\t12\tA",
+    "S\t13\tT",
+    "S\t14\tT",
+    "S\t15\tA",
+    "S\t16\tC",
+    "L\t12\t+\t14\t+\t0M",
+    "L\t13\t+\t14\t+\t0M",
+    "L\t14\t+\t15\t+\t0M",
+    "L\t14\t+\t16\t+\t0M", // Append paths manually.
+  };
+  std::vector<std::vector<std::string>> gfa_paths
+  {
+    {
+      "W\t" + this->reference_samples[0] + "\t0\tA\t1\t4\t>12>14>15\tWT:i:2",
+      "W\tunknown\t1\tA\t0\t3\t>13>14>16\tWT:i:1\tCG:Z:3M", 
+    },
+    {
+      "W\t" + this->reference_samples[1] + "\t0\tA\t1\t4\t>13>14>15\tWT:i:1",
+      "W\tunknown\t1\tA\t0\t3\t>12>14>15\tWT:i:1\tCG:Z:3M", 
+      "W\tunknown\t2\tA\t0\t3\t>13>14>16\tWT:i:1\tCG:Z:3M", 
+    }
+  };
+
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    path_handle_t ref_path;
+    this->find_path(gbz, i, contig_name, ref_path);
+    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::distinct_haplotypes);
+    Subgraph subgraph = this->find_subgraph(gbz, query);
+    this->check_subgraph(gbz, i, subgraph, query, nodes, path_counts[i]);
+
+    std::vector<std::string> true_gfa = gfa;
+    true_gfa[0] += this->reference_samples[i];
+    true_gfa.insert(true_gfa.end(), gfa_paths[i].begin(), gfa_paths[i].end());
+    this->check_gfa(gbz, i, subgraph, query, true_gfa);
+  }
+}
+
+TEST_F(SubgraphQueryTest, NodeBased)
+{
+  // Distinct haplotypes within 2 bp of node 13.
+  nid_t node_id = 13;
+  size_t context = 2;
+  std::set<nid_t> nodes { 11, 12, 13, 14, 15, 16 };
+  std::vector<size_t> path_counts { 2, 3 };
+
+  std::vector<std::string> gfa
+  {
+    "H\tVN:Z:1.1",
+    "S\t11\tG",
+    "S\t12\tA",
+    "S\t13\tT",
+    "S\t14\tT",
+    "S\t15\tA",
+    "S\t16\tC",
+    "L\t11\t+\t12\t+\t0M",
+    "L\t11\t+\t13\t+\t0M",
+    "L\t12\t+\t14\t+\t0M",
+    "L\t13\t+\t14\t+\t0M",
+    "L\t14\t+\t15\t+\t0M",
+    "L\t14\t+\t16\t+\t0M", // Append paths manually.
+  };
+  std::vector<std::vector<std::string>> gfa_paths
+  {
+    {
+      "W\tunknown\t1\tunknown\t0\t4\t>11>12>14>15\tWT:i:2",
+      "W\tunknown\t2\tunknown\t0\t4\t>11>13>14>16\tWT:i:1",
+    },
+    {
+      "W\tunknown\t1\tunknown\t0\t4\t>11>12>14>15\tWT:i:1", 
+      "W\tunknown\t2\tunknown\t0\t4\t>11>13>14>15\tWT:i:1",
+      "W\tunknown\t3\tunknown\t0\t4\t>11>13>14>16\tWT:i:1",
+    }
+  };
+
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    SubgraphQuery query = SubgraphQuery::node(node_id, context, SubgraphQuery::distinct_haplotypes);
+    Subgraph subgraph = this->find_subgraph(gbz, query);
+    this->check_subgraph(gbz, i, subgraph, query, nodes, path_counts[i]);
+
+    std::vector<std::string> true_gfa = gfa;
+    true_gfa.insert(true_gfa.end(), gfa_paths[i].begin(), gfa_paths[i].end());
+    this->check_gfa(gbz, i, subgraph, query, true_gfa);
+  }
+}
+
+TEST_F(SubgraphQueryTest, ReferenceOnly)
+{
+  // Reference haplotype within 1 bp of contig A, offset 2.
+  std::string contig_name = "A";
+  size_t offset = 2, context = 1;
+  std::set<nid_t> nodes { 12, 13, 14, 15, 16 };
+  size_t path_count = 1;
+
+  std::vector<std::string> gfa
+  {
+    "H\tVN:Z:1.1\tRS:Z:", // Append reference sample to line 0.
+    "S\t12\tA",
+    "S\t13\tT",
+    "S\t14\tT",
+    "S\t15\tA",
+    "S\t16\tC",
+    "L\t12\t+\t14\t+\t0M",
+    "L\t13\t+\t14\t+\t0M",
+    "L\t14\t+\t15\t+\t0M",
+    "L\t14\t+\t16\t+\t0M", // Append reference path manually.
+  };
+  std::vector<std::string> reference_paths
+  {
+    "W\t" + this->reference_samples[0] + "\t0\tA\t1\t4\t>12>14>15",
+    "W\t" + this->reference_samples[1] + "\t0\tA\t1\t4\t>13>14>15",
+  };
+
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    path_handle_t ref_path;
+    this->find_path(gbz, i, contig_name, ref_path);
+    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::reference_only);
+    Subgraph subgraph = this->find_subgraph(gbz, query);
+    this->check_subgraph(gbz, i, subgraph, query, nodes, path_count);
+
+    std::vector<std::string> true_gfa = gfa;
+    true_gfa[0] += this->reference_samples[i];
+    true_gfa.push_back(reference_paths[i]);
+    this->check_gfa(gbz, i, subgraph, query, true_gfa);
+  }
+}
+
+TEST_F(SubgraphQueryTest, ContigB)
+{
+  // Distinct haplotypes within 1 bp of contig B, offset 2.
+  std::string contig_name = "B";
+  size_t offset = 2, context = 1;
+  std::set<nid_t> nodes { 22, 23, 24, 25 };
+  std::vector<size_t> path_counts { 2, 3 };
+
+  std::vector<std::string> gfa
+  {
+    "H\tVN:Z:1.1\tRS:Z:", // Append reference sample to line 0.
+    "S\t22\tA",
+    "S\t23\tT",
+    "S\t24\tT",
+    "S\t25\tA",
+    "L\t22\t+\t24\t+\t0M",
+    "L\t23\t+\t24\t-\t0M",
+    "L\t24\t+\t25\t+\t0M", // Append paths manually.
+  };
+  std::vector<std::vector<std::string>> gfa_paths
+  {
+    {
+      "W\t" + this->reference_samples[0] + "\t0\tB\t1\t4\t>22>24>25\tWT:i:2",
+      "W\tunknown\t1\tB\t0\t3\t>22>24<23\tWT:i:1\tCG:Z:3M",
+    },
+    {
+      "W\t" + this->reference_samples[1] + "\t0\tB\t1\t4\t>23<24<22\tWT:i:1",
+      "W\tunknown\t1\tB\t0\t3\t>22>24<23\tWT:i:2\tCG:Z:3M",
+      "W\tunknown\t2\tB\t0\t3\t>22>24>25\tWT:i:1\tCG:Z:3M",
+    }
+  };
+
+  for(size_t i = 0; i < this->graphs.size(); i++)
+  {
+    GBZ gbz = build_gbz(this->graphs[i]);
+    path_handle_t ref_path;
+    this->find_path(gbz, i, contig_name, ref_path);
+    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::distinct_haplotypes);
+    Subgraph subgraph = this->find_subgraph(gbz, query);
+    this->check_subgraph(gbz, i, subgraph, query, nodes, path_counts[i]);
+
+    std::vector<std::string> true_gfa = gfa;
+    true_gfa[0] += this->reference_samples[i];
+    true_gfa.insert(true_gfa.end(), gfa_paths[i].begin(), gfa_paths[i].end());
+    this->check_gfa(gbz, i, subgraph, query, true_gfa);
+  }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace


### PR DESCRIPTION
This PR adds subgraph queries based on a reference path offset / interval or a node id. These are similar to the ones in [GBZ-base](https://github.com/jltsiren/gbz-base). In order to use path-based queries, you first have to build a `PathIndex` for the GBZ graph. See `subgraph_query.cpp` for an example on how to use them.