### PR TITLE
Better subgraph queries

### DIFF
--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -50,7 +50,6 @@ std::vector<handle_t> topological_order(const HandleGraph& graph, const std::uno
 
 //------------------------------------------------------------------------------
 
-// FIXME tests
 /*
   Return the longest common subsequence of the two paths (node sequences), weighted
   by the sequence length of each node. The result is a list of pairs of path offsets.

--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -50,6 +50,22 @@ std::vector<handle_t> topological_order(const HandleGraph& graph, const std::uno
 
 //------------------------------------------------------------------------------
 
+// FIXME tests
+/*
+  Return the longest common subsequence of the two paths (node sequences), weighted
+  by the sequence length of each node. The result is a list of pairs of path offsets.
+
+  The paths are not required to be valid in the graph, but they must consist of
+  valid GBWT node identifiers.
+
+  This is a variant of Myers' O(nd) algorithm.
+*/
+std::vector<std::pair<size_t, size_t>> path_lcs(
+  const GBWTGraph& graph,
+  const gbwt::vector_type& a, const gbwt::vector_type& b);
+
+//------------------------------------------------------------------------------
+
 struct ConstructionJobs
 {
   // Number of nodes in each job.

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -318,6 +318,7 @@ struct LargeRecordCache
 // Sample (sequence offset, GBWT position) at the start of a node approximately
 // every `sample_interval` bp, with the first sample at offset 0.
 // If `length` is not nullptr, it will be set to the length of the path.
+// Sequence offsets are relative to the path, not the full haplotype.
 std::vector<std::pair<size_t, gbwt::edge_type>> sample_path_positions(const GBZ& gbz, path_handle_t path, size_t sample_interval, size_t* length = nullptr);
 
 //------------------------------------------------------------------------------

--- a/include/gbwtgraph/subgraph.h
+++ b/include/gbwtgraph/subgraph.h
@@ -176,6 +176,38 @@ private:
 
 //------------------------------------------------------------------------------
 
+/*
+  An algorithm for aligning a subpath relative to a reference subpath. The two
+  subpaths are assumed to be diverging. The alignment is done under the
+  following assumptions:
+
+  * There may be matching bases at the beginning and the end.
+  * Any matching bases in the middle are considered accidental and treated as
+    mismatches.
+  * Scoring parameters are the same as in vg: match = 1, mismatch = -4,
+    gap open = -6, gap extend = -1.
+  * If multiple operations are used for the middle, the order is mismatch,
+    insertion, deletion.
+
+  The alignment is appended to the given vector of edit operation as pairs
+  ('M', length), ('I', length), or ('D', length), as in CIGAR strings.
+  Successive edits of the same type are merged.
+*/
+void align_diverging(
+  const GBWTGraph& graph,
+  subpath_type path, subpath_type reference,
+  std::vector<std::pair<char, size_t>>& edits
+);
+
+/*
+  Converts a sequence of edit operations to a CIGAR string.
+
+  The edits are given as pairs (type, length).
+*/
+std::string to_cigar(const std::vector<std::pair<char, size_t>>& edits);
+
+//------------------------------------------------------------------------------
+
 } // namespace gbwtgraph
 
 #endif // GBWTGRAPH_SUBGRAPH_H

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -52,13 +52,24 @@ using NamedNodeBackTranslation = handlegraph::NamedNodeBackTranslation;
 //------------------------------------------------------------------------------
 
 // In-place view of the sequence: (start, length).
-// This is a quick replacement to std::string_view from C++17.
+// This is a quick replacement for std::string_view from C++17.
 typedef std::pair<const char*, size_t> view_type;
 
 inline view_type
 str_to_view(const std::string& str)
 {
   return view_type(str.data(), str.length());
+}
+
+// This is the equivalent of `view_type` or `std::string_view` for pats
+// represented as `gbwt::vector_type`.
+typedef std::pair<const gbwt::vector_type::value_type*, size_t> subpath_type;
+
+// Returns a subpath corresponding the half-open interval [from, to) in the given path.
+inline subpath_type
+get_subpath(const gbwt::vector_type& path, size_t from, size_t to)
+{
+  return subpath_type(path.data() + from, to - from);
 }
 
 //------------------------------------------------------------------------------

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -1,6 +1,7 @@
 #include <gbwtgraph/algorithms.h>
 
 #include <limits>
+#include <map>
 #include <stack>
 #include <unordered_map>
 
@@ -235,6 +236,224 @@ topological_order(const HandleGraph& graph, const std::unordered_set<nid_t>& sub
   }
 
   if(result.size() != 2 * (subgraph.size() - missing_nodes)) { result.clear(); }
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
+/*
+  A point in the dynamic programming matrix for LCS computation.
+
+  Each point represents the furthest point reached with the given number of weighted
+  edits on a weighted diagonal. The point itself points to the first unmatched pair
+  of nodes.
+
+  TODO: We could save space by using 32-bit integers.
+  TODO: We could derive the weight using the invariant.
+  TODO: One of the offsets is redunant.
+*/
+struct LCSPoint
+{
+  // Twice the total length of the matched nodes.
+  // The invariant is: weight + edits = a_prefix_sum + b_prefix_sum.
+  size_t weight;
+
+  // Non-weighted offsets in the two sequences.
+  size_t a_offset, b_offset;
+
+  // Length of the non-weighted run of matches ending at this point.
+  size_t matches;
+};
+
+/*
+  Dynamic programming matrix for LCS computation.
+
+  Because the LCS is weighted by sequence length, we precompute prefix sums of weights
+  over both paths. The algorithm is a variant of Myers' O(nd) algorithm. We therefore
+  store only the furthest points reached with each (weighted) number of edits on each
+  (weighted) diagonal.
+
+  TODO: We could save space by using 32-bit integers.
+*/
+struct LCSMatrix
+{
+  const gbwt::vector_type& a;
+  const gbwt::vector_type& b;
+
+  // Prefix sums of sequence lengths on the two paths.
+  std::vector<size_t> a_prefix_sum, b_prefix_sum;
+
+  // The final result if we have found it.
+  LCSPoint result;
+
+  // Furthest point reached for each (weighted number of edits, weighted diagonal).
+  // A diagonal is a_prefix_sum - b_prefix_sum.
+  // The point refers to the first unmatched pair of nodes.
+  std::map<std::pair<size_t, std::int64_t>, LCSPoint> points;
+
+  LCSMatrix(const GBWTGraph& graph, const gbwt::vector_type& a, const gbwt::vector_type& b) :
+    a(a), b(b), a_prefix_sum(a.size() + 1, 0), b_prefix_sum(b.size() + 1, 0),
+    result({ 0, 0, 0, 0 })
+  {
+    for(size_t i = 1; i <= a.size(); i++)
+    {
+      this->a_prefix_sum[i] = this->a_prefix_sum[i - 1] + graph.get_length(GBWTGraph::node_to_handle(a[i - 1]));
+    }
+    for(size_t i = 1; i <= b.size(); i++)
+    {
+      this->b_prefix_sum[i] = this->b_prefix_sum[i - 1] + graph.get_length(GBWTGraph::node_to_handle(b[i - 1]));
+    }
+  }
+
+  // Returns the sorted set of diagonals for the given number of edits.
+  std::vector<std::int64_t> diagonals(size_t edits) const
+  {
+    auto low = this->points.lower_bound(std::make_pair(edits, std::numeric_limits<std::int64_t>::min()));
+    auto high = this->points.lower_bound(std::make_pair(edits + 1, std::numeric_limits<std::int64_t>::min()));
+    std::vector<std::int64_t> result;
+    for(auto iter = low; iter != high; ++iter)
+    {
+      result.push_back(iter->first.second);
+    }
+  }
+
+  // Inserts the point if it is better than the existing one.
+  void try_insert(size_t edits, std::int64_t diagonal, LCSPoint point)
+  {
+    auto iter = this->points.find(std::make_pair(edits, diagonal));
+    if(iter == this->points.end())
+    {
+      this->points[std::make_pair(edits, diagonal)] = point;
+    }
+    else if(point.weight > iter->second.weight)
+    {
+      iter->second = point;
+    }
+  }
+
+  size_t a_weight(size_t offset) const
+  {
+    return this->a_prefix_sum[offset + 1] - this->a_prefix_sum[offset];
+  }
+
+  size_t b_weight(size_t offset) const
+  {
+    return this->b_prefix_sum[offset + 1] - this->b_prefix_sum[offset];
+  }
+
+  // Extends matches over all diagonals for the given number of weighted edits.
+  // Also adds successor points reachable with a single edit from each extension.
+  // Returns true and sets the point if we reached the end.
+  bool extend(size_t edits)
+  {
+    std::vector<std::int64_t> diagonals = this->diagonals(edits);
+    for(std::int64_t diagonal : diagonals)
+    {
+      auto iter = this->points.find(std::make_pair(edits, diagonal));
+      if(iter == this->points.end()) { continue; }
+      LCSPoint point = iter->second; // Copy the point to avoid iterator invalidation.
+      while(point.a_offset < this->a.size() && point.b_offset < this->b.size() && this->a[point.a_offset] == this->b[point.b_offset])
+      {
+        point.weight += 2 * this->a_weight(point.a_offset);
+        point.a_offset++; point.b_offset++; point.matches++;
+      }
+      if(point.matches > 0) { this->points[std::make_pair(edits, diagonal)] = point; }
+      if(point.a_offset == this->a.size() || point.b_offset == this->b.size())
+      {
+        this->result = point;
+        return true;
+      }
+      if(point.a_offset < this->a.size())
+      {
+        size_t weight = this->a_weight(point.a_offset);
+        LCSPoint new_point { point.weight, point.a_offset + 1, point.b_offset, 0 };
+        this->try_insert(edits + weight, diagonal + std::int64_t(weight), new_point);
+      }
+      if(point.b_offset < this->b.size())
+      {
+        size_t weight = this->b_weight(point.b_offset);
+        LCSPoint new_point { point.weight, point.a_offset, point.b_offset + 1, 0 };
+        this->try_insert(edits + weight, diagonal - std::int64_t(weight), new_point);
+      }
+    }
+    return false;
+  }
+
+  // Returns the next possible number of edits after the given number of edits.
+  // Assumes that extend() has already been called for the given number of edits.
+  // Returns std::numeric_limits<size_t>::max() if there are no more possible edits.
+  size_t next_edits(size_t edits) const
+  {
+    auto iter = this->points.lower_bound(std::make_pair(edits + 1, std::numeric_limits<std::int64_t>::min()));
+    return (iter == this->points.end() ? std::numeric_limits<size_t>::max() : iter->first.first);
+  }
+
+  // Returns the predecessor point and number of edits for the given point and number of edits.
+  std::pair<LCSPoint, size_t> predecessor(size_t a_offset, size_t b_offset, size_t edits) const
+  {
+    std::int64_t diagonal = std::int64_t(this->a_prefix_sum[a_offset]) - std::int64_t(this->b_prefix_sum[b_offset]);
+    auto prev = this->points.end();
+    if(a_offset > 0 && this->a_weight(a_offset - 1) > 0)
+    {
+      size_t weight = this->a_weight(a_offset - 1);
+      prev = this->points.find(std::make_pair(edits - weight, diagonal - std::int64_t(weight)));
+    }
+    auto next = this->points.end();
+    if(b_offset > 0 && this->b_weight(b_offset - 1) > 0)
+    {
+      size_t weight = this->b_weight(b_offset - 1);
+      next = this->points.find(std::make_pair(edits - weight, diagonal + std::int64_t(weight)));
+    }
+    if(prev != this->points.end() && next != this->points.end())
+    {
+      return (prev->second.weight > next->second.weight ?
+        std::make_pair(prev->second, prev->first.first) :
+        std::make_pair(next->second, next->first.first));
+    }
+    else if(prev != this->points.end())
+    {
+      return std::make_pair(prev->second, prev->first.first);
+    }
+    else if(next != this->points.end())
+    {
+      return std::make_pair(next->second, next->first.first);
+    }
+    else
+    {
+      return std::make_pair(LCSPoint { 0, 0, 0, 0 }, 0);
+    }
+  }
+};
+
+std::vector<std::pair<size_t, size_t>>
+path_lcs(const GBWTGraph& graph, const gbwt::vector_type& a, const gbwt::vector_type& b)
+{
+  if(a.empty() || b.empty()) { return {}; }
+
+  // Find the furthest point on each diagonal with each possible number of edits, until we reach the end.
+  LCSMatrix matrix(graph, a, b);
+  size_t edits = 0;
+  while(true)
+  {
+    if(matrix.extend(edits)) { break; }
+    edits = matrix.next_edits(edits);
+    if(edits == std::numeric_limits<size_t>::max()) { break; }
+  }
+
+  // Trace back the LCS.
+  std::vector<std::pair<size_t, size_t>> result;
+  LCSPoint point = matrix.result;
+  while(point.a_offset > 0 || point.b_offset > 0)
+  {
+    for(size_t i = 0; i < point.matches; i++)
+    {
+      point.a_offset--; point.b_offset--;
+      result.push_back(std::make_pair(a[point.a_offset], b[point.b_offset]));
+    }
+    std::tie(point, edits) = matrix.predecessor(point.a_offset, point.b_offset, edits);
+  }
+  std::reverse(result.begin(), result.end());
+
   return result;
 }
 

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -303,6 +303,7 @@ struct LCSMatrix
     {
       this->b_prefix_sum[i] = this->b_prefix_sum[i - 1] + graph.get_length(GBWTGraph::node_to_handle(b[i - 1]));
     }
+    this->points[std::make_pair(0, 0)] = { 0, 0, 0, 0 };
   }
 
   // Returns the sorted set of diagonals for the given number of edits.
@@ -315,6 +316,7 @@ struct LCSMatrix
     {
       result.push_back(iter->first.second);
     }
+    return result;
   }
 
   // Inserts the point if it is better than the existing one.
@@ -358,7 +360,7 @@ struct LCSMatrix
         point.a_offset++; point.b_offset++; point.matches++;
       }
       if(point.matches > 0) { this->points[std::make_pair(edits, diagonal)] = point; }
-      if(point.a_offset == this->a.size() || point.b_offset == this->b.size())
+      if(point.a_offset == this->a.size() && point.b_offset == this->b.size())
       {
         this->result = point;
         return true;
@@ -448,7 +450,7 @@ path_lcs(const GBWTGraph& graph, const gbwt::vector_type& a, const gbwt::vector_
     for(size_t i = 0; i < point.matches; i++)
     {
       point.a_offset--; point.b_offset--;
-      result.push_back(std::make_pair(a[point.a_offset], b[point.b_offset]));
+      result.push_back(std::make_pair(point.a_offset, point.b_offset));
     }
     std::tie(point, edits) = matrix.predecessor(point.a_offset, point.b_offset, edits);
   }

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -1776,6 +1776,7 @@ gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, const GFAExtractionParame
   writer.flush();
 
   // Write the links and paths using multiple threads.
+  int old_threads = omp_get_max_threads();
   omp_set_num_threads(parameters.threads());
   write_links(graph, segment_cache, out, parameters);
   if(sufficient_metadata)
@@ -1800,6 +1801,9 @@ gbwt_to_gfa(const GBWTGraph& graph, std::ostream& out, const GFAExtractionParame
     std::cerr << "Warning: No metadata available, writing all paths as P-lines" << std::endl;
     write_all_paths(graph, segment_cache, record_cache, out, parameters);
   }
+
+  // Restore the number of threads.
+  omp_set_num_threads(old_threads);
 }
 
 //------------------------------------------------------------------------------

--- a/tests/gfas/fragmented.gfa
+++ b/tests/gfas/fragmented.gfa
@@ -1,0 +1,25 @@
+H	VN:Z:1.1	RS:Z:ref
+# The designated reference sample is fragmented, missing node 4/5.
+S	1	GAT
+S	2	TA
+S	3	CA
+S	4	C
+S	5	G
+S	6	ATTA
+S	7	C
+S	8	G
+S	9	AT
+L	1	+	2	+	0M
+L	2	+	3	+	0M
+L	3	+	4	+	0M
+L	3	+	5	+	0M
+L	4	+	6	+	0M
+L	5	+	6	+	0M
+L	6	+	7	+	0M
+L	6	+	8	+	0M
+L	7	+	9	+	0M
+L	8	+	9	+	0M
+W	ref	0	contig	0	7	>1>2>3
+W	ref	0	contig	8	15	>6>7>9
+W	sample	1	contig	0	15	>1>2>3>4>6>8>9
+W	sample	2	contig	0	15	>1>2>3>5>6>7>9

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -59,21 +59,10 @@ gbwt::vector_type empty_path
 {
 };
 
-// Build a GBWT with three paths including a duplicate, plus n empty paths.
+// Build a GBWT index for the given paths without metadata.
 inline gbwt::GBWT
-build_gbwt_index(size_t empty_paths = 0)
+build_gbwt(const std::vector<gbwt::vector_type>& paths)
 {
-  std::vector<gbwt::vector_type> paths
-  {
-    short_path, alt_path, short_path
-  };
-
-  for(size_t i = 0; i < empty_paths; i++)
-  {
-    paths.push_back(empty_path);
-  }
-
-  // Determine node width in bits.
   gbwt::size_type node_width = 1, total_length = 0;
   for(auto& path : paths)
   {
@@ -92,6 +81,21 @@ build_gbwt_index(size_t empty_paths = 0)
   return gbwt::GBWT(builder.index);
 }
 
+// Build a GBWT with three paths including a duplicate, plus n empty paths.
+inline gbwt::GBWT
+build_gbwt_index(size_t empty_paths = 0)
+{
+  std::vector<gbwt::vector_type> paths
+  {
+    short_path, alt_path, short_path
+  };
+  for(size_t i = 0; i < empty_paths; i++)
+  {
+    paths.push_back(empty_path);
+  }
+  return build_gbwt(paths);
+}
+
 // Build a GBWT with 6 paths, 3 duplicates of each.
 // TODO: what's the "ref" here?
 // This should be identical to gfas/example_walks.gfa
@@ -103,24 +107,7 @@ build_gbwt_index_with_ref()
     short_path, alt_path, alt_path,
     short_path, alt_path, short_path
   };
-
-  // Determine node width in bits.
-  gbwt::size_type node_width = 1, total_length = 0;
-  for(auto& path : paths)
-  {
-    for(auto node : path)
-    {
-      node_width = std::max(node_width, gbwt::size_type(sdsl::bits::length(gbwt::Node::encode(node, true))));
-    }
-    total_length += 2 * (path.size() + 1);
-  }
-
-  gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-  gbwt::GBWTBuilder builder(node_width, total_length);
-  for(auto& path : paths) { builder.insert(path, true); }
-  builder.finish();
-  
-  return builder.index;
+  return build_gbwt(paths);
 }
 
 // This should be identical to gfas/example_walks.gfa, modulo name ordering.

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -436,4 +436,219 @@ TEST_F(TopologicalOrderTest, MissingNodes)
 
 //------------------------------------------------------------------------------
 
+class LCSTest : public ::testing::Test
+{
+public:
+  gbwt::GBWT index;
+  GBWTGraph graph;
+  std::mt19937_64 rng;
+  std::vector<nid_t> node_ids;
+
+  LCSTest() :
+    rng(0xACDCABBABABA ^ std::random_device()())
+  {
+  }
+
+  void SetUp() override
+  {
+    // This graph contains nodes 1 to 8 with variable length sequences.
+    auto gfa_parse = gfa_to_gbwt("gfas/for_subgraph.gfa");
+    this->index = *(gfa_parse.first);
+    this->graph = GBWTGraph(this->index, *(gfa_parse.second));
+    this->graph.for_each_handle([&](const handle_t& handle)
+    {
+      this->node_ids.push_back(this->graph.get_id(handle));
+    });
+  }
+
+  void compare_paths(const gbwt::vector_type& left, const gbwt::vector_type& right, const std::string& name)
+  {
+    std::vector<std::pair<size_t, size_t>> result = path_lcs(this->graph, left, right);
+    for(size_t i = 0; i < result.size(); i++)
+    {
+      ASSERT_LT(result[i].first, left.size()) << "Invalid left LCS position " << i << " for " << name;
+      ASSERT_LT(result[i].second, right.size()) << "Invalid right LCS position " << i << " for " << name;
+      if(i > 0)
+      {
+        ASSERT_LT(result[i - 1].first, result[i].first) << "Non-increasing left LCS position " << i << " for " << name;
+        ASSERT_LT(result[i - 1].second, result[i].second) << "Non-increasing right LCS position " << i << " for " << name;
+      }
+      ASSERT_EQ(left[result[i].first], right[result[i].second]) << "Incorrect LCS element " << i << " for " << name;
+    }
+  }
+
+  gbwt::vector_type forward_path(const std::vector<nid_t>& nodes)
+  {
+    gbwt::vector_type result;
+    for(nid_t node : nodes)
+    {
+      result.push_back(gbwt::Node::encode(node, false));
+    }
+    return result;
+  }
+
+  gbwt::vector_type random_path(size_t length)
+  {
+    gbwt::vector_type result;
+    std::uniform_int_distribution<size_t> dist(0, this->node_ids.size() - 1);
+    for(size_t i = 0; i < length; i++)
+    {
+      nid_t node = this->node_ids[dist(this->rng)];
+      result.push_back(gbwt::Node::encode(node, false));
+    }
+    return result;
+  }
+
+  gbwt::vector_type mutate_path(const gbwt::vector_type& path, double rate)
+  {
+    gbwt::vector_type result = path;
+    std::uniform_real_distribution<double> mutate(0.0, 1.0);
+    std::uniform_int_distribution<size_t> node_dist(0, this->node_ids.size() - 1);
+    for(size_t i = 0; i < result.size(); i++)
+    {
+      if(mutate(this->rng) < rate)
+      {
+        nid_t node = this->node_ids[node_dist(this->rng)];
+        result[i] = gbwt::Node::encode(node, false);
+      }
+    }
+    return result;
+  }
+};
+
+TEST_F(LCSTest, EmptyLCS)
+{
+  gbwt::vector_type empty;
+  gbwt::vector_type path = this->index.extract(gbwt::Path::encode(0, false));
+
+  ASSERT_TRUE(path_lcs(this->graph, empty, empty).empty()) << "Nonempty LCS for two empty paths";
+  ASSERT_TRUE(path_lcs(this->graph, empty, path).empty()) << "Nonempty LCS for an empty first path";
+  ASSERT_TRUE(path_lcs(this->graph, path, empty).empty()) << "Nonempty LCS for an empty second path";
+
+  gbwt::vector_type reverse = this->index.extract(gbwt::Path::encode(0, true));
+  ASSERT_TRUE(path_lcs(this->graph, path, reverse).empty()) << "Nonempty LCS for non-overlapping paths";
+}
+
+TEST_F(LCSTest, IndenticalLCS)
+{
+  for(gbwt::size_type i = 0; i < this->index.sequences(); i++)
+  {
+    gbwt::vector_type path = this->index.extract(i);
+    std::vector<std::pair<size_t, size_t>> truth;
+    for(size_t j = 0; j < path.size(); j++)
+    {
+      truth.push_back(std::make_pair(j, j));
+    }
+    std::vector<std::pair<size_t, size_t>> result = path_lcs(this->graph, path, path);
+    gbwt::size_type id = gbwt::Path::id(i);
+    bool orientation = gbwt::Path::is_reverse(i);
+    ASSERT_EQ(result, truth) << "Incorrect LCS for path " << id << ", orientation " << orientation << " with itself";
+  }
+}
+
+TEST_F(LCSTest, FirstLastLCS)
+{
+  gbwt::vector_type path = this->forward_path({ 1, 2, 3, 4, 5 });
+
+  gbwt::vector_type no_no = this->forward_path({ 6, 2, 4, 7 });
+  std::vector<std::pair<size_t, size_t>> no_no_left = { { 1, 1 }, { 2, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, no_no, path), no_no_left) << "Incorrect LCS for no first, no last, left";
+  std::vector<std::pair<size_t, size_t>> no_no_right = { { 1, 1 }, { 3, 2 } };
+  ASSERT_EQ(path_lcs(this->graph, path, no_no), no_no_right) << "Incorrect LCS for no first, no last, right";
+
+  gbwt::vector_type no_yes = this->forward_path({ 6, 2, 4, 5 });
+  std::vector<std::pair<size_t, size_t>> no_yes_left = { { 1, 1 }, { 2, 3 }, { 3, 4 } };
+  ASSERT_EQ(path_lcs(this->graph, no_yes, path), no_yes_left) << "Incorrect LCS for no first, yes last, left";
+  std::vector<std::pair<size_t, size_t>> no_yes_right = { { 1, 1 }, { 3, 2 }, { 4, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, path, no_yes), no_yes_right) << "Incorrect LCS for no first, yes last, right";
+
+  gbwt::vector_type yes_no = this->forward_path({ 1, 2, 4, 7 });
+  std::vector<std::pair<size_t, size_t>> yes_no_left = { { 0, 0 }, { 1, 1 }, { 2, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, yes_no, path), yes_no_left) << "Incorrect LCS for yes first, no last, left";
+  std::vector<std::pair<size_t, size_t>> yes_no_right = { { 0, 0 }, { 1, 1 }, { 3, 2 } };
+  ASSERT_EQ(path_lcs(this->graph, path, yes_no), yes_no_right) << "Incorrect LCS for yes first, no last, right";
+
+  gbwt::vector_type yes_yes = this->forward_path({ 1, 2, 4, 5 });
+  std::vector<std::pair<size_t, size_t>> yes_yes_left = { { 0, 0 }, { 1, 1 }, { 2, 3 }, { 3, 4 } };
+  ASSERT_EQ(path_lcs(this->graph, yes_yes, path), yes_yes_left) << "Incorrect LCS for yes first, yes last, left";
+  std::vector<std::pair<size_t, size_t>> yes_yes_right = { { 0, 0 }, { 1, 1 }, { 3, 2 }, { 4, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, path, yes_yes), yes_yes_right) << "Incorrect LCS for yes first, yes last, right";
+}
+
+TEST_F(LCSTest, MinimalMaximalLCS)
+{
+  gbwt::vector_type three_odd = this->forward_path({ 1, 3, 5 });
+  gbwt::vector_type four_odd = this->forward_path({ 1, 3, 5, 7 });
+  gbwt::vector_type three_even = this->forward_path({ 4, 6, 8 });
+  gbwt::vector_type four_even = this->forward_path({ 2, 4, 6, 8 });
+
+  ASSERT_TRUE(path_lcs(this->graph, four_odd, four_even).empty()) << "Nonempty LCS for non-overlapping paths";
+
+  std::vector<std::pair<size_t, size_t>> four_four { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, four_odd, four_odd), four_four) << "Incorrect LCS for identical paths";
+
+  std::vector<std::pair<size_t, size_t>> prefix { { 0, 0 }, { 1, 1 }, { 2, 2 } };
+  ASSERT_EQ(path_lcs(this->graph, three_odd, four_odd), prefix) << "Incorrect LCS for prefix / full";
+  ASSERT_EQ(path_lcs(this->graph, four_odd, three_odd), prefix) << "Incorrect LCS for full / prefix";
+
+  std::vector<std::pair<size_t, size_t>> left_suffix { { 0, 1 }, { 1, 2 }, { 2, 3 } };
+  ASSERT_EQ(path_lcs(this->graph, three_even, four_even), left_suffix) << "Incorrect LCS for suffix / full";
+  std::vector<std::pair<size_t, size_t>> right_suffix { { 1, 0 }, { 2, 1 }, { 3, 2 } };
+  ASSERT_EQ(path_lcs(this->graph, four_even, three_even), right_suffix) << "Incorrect LCS for full / suffix";
+}
+
+TEST_F(LCSTest, RandomLCS)
+{
+  for(size_t length : { 10, 30, 100, 300 })
+  {
+    gbwt::vector_type left = this->random_path(length);
+    gbwt::vector_type right = this->random_path(length);
+    std::string name = "(length " + std::to_string(length) + ")";
+    this->compare_paths(left, right, name);
+  }
+}
+
+TEST_F(LCSTest, RealLCS)
+{
+  gbwt::size_type paths = this->index.metadata.paths();
+  for(gbwt::size_type left_id = 0; left_id < paths; left_id++)
+  {
+    for(gbwt::size_type right_id = 0; right_id < paths; right_id++)
+    {
+      for(bool orientation : { false, true })
+      {
+        gbwt::vector_type left = this->index.extract(gbwt::Path::encode(left_id, orientation));
+        gbwt::vector_type right = this->index.extract(gbwt::Path::encode(right_id, orientation));
+        std::string name = "(paths " + std::to_string(left_id) + " and " + std::to_string(right_id) + " " + (orientation ? "reverse" : "forward") + ")";
+        this->compare_paths(left, right, name);
+      }
+    }
+  }
+}
+
+TEST_F(LCSTest, LCSWeights)
+{
+  // This is an artificial scenario where node lengths matter.
+  // Nodes 3 and 6 are long nodes, while nodes 5, 7, and 8 are short nodes.
+  gbwt::vector_type left = this->forward_path({ 2, 3, 6, 5, 7, 8 });
+  gbwt::vector_type right = this->forward_path({ 2, 5, 7, 8, 3, 6 });
+  std::vector<std::pair<size_t, size_t>> truth = { { 0, 0 }, { 1, 4 }, { 2, 5 } };
+  std::vector<std::pair<size_t, size_t>> result = path_lcs(this->graph, left, right);
+  ASSERT_EQ(result, truth) << "Incorrect LCS weighted by node lengths";
+}
+
+TEST_F(LCSTest, SimilarLCS)
+{
+  std::vector<std::pair<size_t, double>> params = { { 100, 0.02 }, { 1000, 0.01 }, { 10000, 0.005 }, { 30000, 0.005 } };
+  for(std::pair<size_t, double> test : params)
+  {
+    gbwt::vector_type left = this->random_path(test.first);
+    gbwt::vector_type right = this->mutate_path(left, test.second);
+    std::string name = "(length " + std::to_string(test.first) + ", mutation rate " + std::to_string(test.second) + ")";
+    this->compare_paths(left, right, name);
+  }
+}
+
+//------------------------------------------------------------------------------
+
 } // namespace

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -477,7 +477,7 @@ public:
     }
   }
 
-  gbwt::vector_type forward_path(const std::vector<nid_t>& nodes)
+  static gbwt::vector_type forward_path(const std::vector<nid_t>& nodes)
   {
     gbwt::vector_type result;
     for(nid_t node : nodes)
@@ -548,27 +548,27 @@ TEST_F(LCSTest, IndenticalLCS)
 
 TEST_F(LCSTest, FirstLastLCS)
 {
-  gbwt::vector_type path = this->forward_path({ 1, 2, 3, 4, 5 });
+  gbwt::vector_type path = forward_path({ 1, 2, 3, 4, 5 });
 
-  gbwt::vector_type no_no = this->forward_path({ 6, 2, 4, 7 });
+  gbwt::vector_type no_no = forward_path({ 6, 2, 4, 7 });
   std::vector<std::pair<size_t, size_t>> no_no_left = { { 1, 1 }, { 2, 3 } };
   ASSERT_EQ(path_lcs(this->graph, no_no, path), no_no_left) << "Incorrect LCS for no first, no last, left";
   std::vector<std::pair<size_t, size_t>> no_no_right = { { 1, 1 }, { 3, 2 } };
   ASSERT_EQ(path_lcs(this->graph, path, no_no), no_no_right) << "Incorrect LCS for no first, no last, right";
 
-  gbwt::vector_type no_yes = this->forward_path({ 6, 2, 4, 5 });
+  gbwt::vector_type no_yes = forward_path({ 6, 2, 4, 5 });
   std::vector<std::pair<size_t, size_t>> no_yes_left = { { 1, 1 }, { 2, 3 }, { 3, 4 } };
   ASSERT_EQ(path_lcs(this->graph, no_yes, path), no_yes_left) << "Incorrect LCS for no first, yes last, left";
   std::vector<std::pair<size_t, size_t>> no_yes_right = { { 1, 1 }, { 3, 2 }, { 4, 3 } };
   ASSERT_EQ(path_lcs(this->graph, path, no_yes), no_yes_right) << "Incorrect LCS for no first, yes last, right";
 
-  gbwt::vector_type yes_no = this->forward_path({ 1, 2, 4, 7 });
+  gbwt::vector_type yes_no = forward_path({ 1, 2, 4, 7 });
   std::vector<std::pair<size_t, size_t>> yes_no_left = { { 0, 0 }, { 1, 1 }, { 2, 3 } };
   ASSERT_EQ(path_lcs(this->graph, yes_no, path), yes_no_left) << "Incorrect LCS for yes first, no last, left";
   std::vector<std::pair<size_t, size_t>> yes_no_right = { { 0, 0 }, { 1, 1 }, { 3, 2 } };
   ASSERT_EQ(path_lcs(this->graph, path, yes_no), yes_no_right) << "Incorrect LCS for yes first, no last, right";
 
-  gbwt::vector_type yes_yes = this->forward_path({ 1, 2, 4, 5 });
+  gbwt::vector_type yes_yes = forward_path({ 1, 2, 4, 5 });
   std::vector<std::pair<size_t, size_t>> yes_yes_left = { { 0, 0 }, { 1, 1 }, { 2, 3 }, { 3, 4 } };
   ASSERT_EQ(path_lcs(this->graph, yes_yes, path), yes_yes_left) << "Incorrect LCS for yes first, yes last, left";
   std::vector<std::pair<size_t, size_t>> yes_yes_right = { { 0, 0 }, { 1, 1 }, { 3, 2 }, { 4, 3 } };
@@ -577,10 +577,10 @@ TEST_F(LCSTest, FirstLastLCS)
 
 TEST_F(LCSTest, MinimalMaximalLCS)
 {
-  gbwt::vector_type three_odd = this->forward_path({ 1, 3, 5 });
-  gbwt::vector_type four_odd = this->forward_path({ 1, 3, 5, 7 });
-  gbwt::vector_type three_even = this->forward_path({ 4, 6, 8 });
-  gbwt::vector_type four_even = this->forward_path({ 2, 4, 6, 8 });
+  gbwt::vector_type three_odd = forward_path({ 1, 3, 5 });
+  gbwt::vector_type four_odd = forward_path({ 1, 3, 5, 7 });
+  gbwt::vector_type three_even = forward_path({ 4, 6, 8 });
+  gbwt::vector_type four_even = forward_path({ 2, 4, 6, 8 });
 
   ASSERT_TRUE(path_lcs(this->graph, four_odd, four_even).empty()) << "Nonempty LCS for non-overlapping paths";
 
@@ -630,8 +630,8 @@ TEST_F(LCSTest, LCSWeights)
 {
   // This is an artificial scenario where node lengths matter.
   // Nodes 3 and 6 are long nodes, while nodes 5, 7, and 8 are short nodes.
-  gbwt::vector_type left = this->forward_path({ 2, 3, 6, 5, 7, 8 });
-  gbwt::vector_type right = this->forward_path({ 2, 5, 7, 8, 3, 6 });
+  gbwt::vector_type left = forward_path({ 2, 3, 6, 5, 7, 8 });
+  gbwt::vector_type right = forward_path({ 2, 5, 7, 8, 3, 6 });
   std::vector<std::pair<size_t, size_t>> truth = { { 0, 0 }, { 1, 4 }, { 2, 5 } };
   std::vector<std::pair<size_t, size_t>> result = path_lcs(this->graph, left, right);
   ASSERT_EQ(result, truth) << "Incorrect LCS weighted by node lengths";

--- a/tests/test_subgraph.cpp
+++ b/tests/test_subgraph.cpp
@@ -102,6 +102,276 @@ TEST_F(PathIndexTest, NonIndexedPaths)
 
 //------------------------------------------------------------------------------
 
+class AlignDivergingTest : public ::testing::Test
+{
+public:
+  gbwt::GBWT index;
+  GBWTGraph graph;
+
+  void SetUp() override
+  {
+    std::vector<gbwt::vector_type> paths
+    {
+      forward_path({ 1, 2, 3, 4, 5, 6 })
+    };
+    this->index = build_gbwt(paths);
+
+    std::vector<std::pair<nid_t, std::string>> nodes
+    {
+      { 1, "A" },
+      { 2, "C" },
+      { 3, "AA" },
+      { 4, "CC" },
+      { 5, "ACA" },
+      { 6, "CAC" }
+    };
+    SequenceSource source;
+    for(const auto& node : nodes)
+    {
+      source.add_node(node.first, node.second);
+    }
+    this->graph = GBWTGraph(this->index, source);
+  }
+
+  static gbwt::vector_type forward_path(const std::vector<nid_t>& nodes)
+  {
+    gbwt::vector_type result;
+    for(nid_t node : nodes)
+    {
+      result.push_back(gbwt::Node::encode(node, false));
+    }
+    return result;
+  }
+
+  void check_edits(
+    const gbwt::vector_type& path, const gbwt::vector_type& reference,
+    const std::vector<std::pair<char, size_t>>& truth,
+    const std::string& name
+  ) const
+  {
+    std::vector<std::pair<char, size_t>> edits;
+    align_diverging(
+      this->graph,
+      get_subpath(path, 0, path.size()),
+      get_subpath(reference, 0, reference.size()),
+      edits
+    );
+    ASSERT_EQ(edits.size(), truth.size()) << "Invalid number of edits for " << name;
+    for(size_t i = 0; i < edits.size(); i++)
+    {
+      EXPECT_EQ(edits[i], truth[i]) << "Invalid edit " << i << " for " << name;
+    }
+  }
+};
+
+TEST_F(AlignDivergingTest, SpecialCases)
+{
+  gbwt::vector_type empty;
+  gbwt::vector_type non_empty = forward_path({ 5, 6 });
+
+  // (empty, empty)
+  {
+    std::vector<std::pair<char, size_t>> truth;
+    this->check_edits(empty, empty, truth, "empty paths");
+  }
+
+  // (empty, non-empty)
+  {
+    std::vector<std::pair<char, size_t>> truth { { 'D', 6 } };
+    this->check_edits(empty, non_empty, truth, "empty vs. non-empty paths");
+  }
+
+  // (non-empty, empty)
+  {
+    std::vector<std::pair<char, size_t>> truth { { 'I', 6 } };
+    this->check_edits(non_empty, empty, truth, "non-empty vs. empty paths");
+  }
+
+  // (non-empty, non-empty)
+  {
+    std::vector<std::pair<char, size_t>> truth { { 'M', 6 } };
+    this->check_edits(non_empty, non_empty, truth, "identical paths");
+  }
+
+  // Identical bases, different paths.
+  {
+    gbwt::vector_type path = forward_path({ 1, 5, 3 }); // AACAAA
+    gbwt::vector_type reference = forward_path({ 3, 2, 1, 3 }); // AACAAA
+    std::vector<std::pair<char, size_t>> truth { { 'M', 6 } };
+    this->check_edits(path, reference, truth, "identical bases, different paths");
+  }
+
+  // Prefix + suffix length exceeds the length of the shorter path.
+  {
+    gbwt::vector_type short_path = forward_path({ 5, 5 }); // ACAACA
+    gbwt::vector_type long_path = forward_path({ 1, 2, 3, 5, 3, 2, 1 }); // ACAAACAAACA
+    std::vector<std::pair<char, size_t>> path_is_short { { 'M', 4 }, { 'D', 5 }, { 'M', 2 } };
+    std::vector<std::pair<char, size_t>> path_is_long { { 'M', 4 }, { 'I', 5 }, { 'M', 2 } };
+    this->check_edits(short_path, long_path, path_is_short, "prefix + suffix length exceeds path length");
+    this->check_edits(long_path, short_path, path_is_long, "prefix + suffix length exceeds reference length");
+  }
+}
+
+TEST_F(AlignDivergingTest, NoPrefixNoSuffix)
+{
+  // Insertion and deletion are in SpecialCases.
+
+  // Mismatch + insertion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 2, 5 }); // ACACA
+    gbwt::vector_type reference = forward_path({ 4 }); // CC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'I', 3 } };
+    this->check_edits(path, reference, truth, "mismatch + insertion");
+  }
+
+  // Mismatch + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 3 }); // AA
+    gbwt::vector_type reference = forward_path({ 2, 1, 6 }); // CACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'D', 3 } };
+    this->check_edits(path, reference, truth, "mismatch + deletion");
+  }
+
+  // Insertion + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 2, 5, 3 }); // ACACAAA
+    gbwt::vector_type reference = forward_path({ 4, 2, 1, 6 }); // CCCACAC
+    std::vector<std::pair<char, size_t>> truth { { 'I', 7 }, { 'D', 7 } };
+    this->check_edits(path, reference, truth, "insertion + deletion");
+  }
+}
+
+TEST_F(AlignDivergingTest, NoPrefixWithSuffix)
+{
+  // Insertion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 2, 5 }); // ACACA
+    gbwt::vector_type reference = forward_path({ 2, 1 }); // CA
+    std::vector<std::pair<char, size_t>> truth { { 'I', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "insertion");
+  }
+
+  // Deletion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 2 }); // AC
+    gbwt::vector_type reference = forward_path({ 2, 1, 6 }); // CACAC
+    std::vector<std::pair<char, size_t>> truth { { 'D', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "deletion");
+  }
+
+  // Mismatch + insertion.
+  {
+    gbwt::vector_type path = forward_path({ 5, 2, 5 }); // ACACACA
+    gbwt::vector_type reference = forward_path({ 4, 2, 1 }); // CCCA
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'I', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "mismatch + insertion");
+  }
+
+  // Mismatch + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 3, 1, 2 }); // AAAC
+    gbwt::vector_type reference = forward_path({ 6, 1, 6 }); // CACACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'D', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "mismatch + deletion");
+  }
+
+  // Insertion + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 3, 2, 5, 5 }); // AACACAACA
+    gbwt::vector_type reference = forward_path({ 4, 2, 1, 6, 1 }); // CCCACACA
+    std::vector<std::pair<char, size_t>> truth { { 'I', 6 }, { 'D', 5 }, { 'M', 3 } };
+    this->check_edits(path, reference, truth, "insertion + deletion");
+  }
+}
+
+TEST_F(AlignDivergingTest, WithPrefixNoSuffix)
+{
+  // Insertion.
+  {
+    gbwt::vector_type path = forward_path({ 5, 2, 1 }); // ACACA
+    gbwt::vector_type reference = forward_path({ 1, 2 }); // AC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'I', 3 } };
+    this->check_edits(path, reference, truth, "insertion");
+  }
+
+  // Deletion.
+  {
+    gbwt::vector_type path = forward_path({ 2, 1 }); // CA
+    gbwt::vector_type reference = forward_path({ 6, 1, 2 }); // CACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'D', 3 } };
+    this->check_edits(path, reference, truth, "deletion");
+  }
+
+  // Mismatch + insertion.
+  {
+    gbwt::vector_type path = forward_path({ 5, 2, 5 }); // ACACACA
+    gbwt::vector_type reference = forward_path({ 1, 2, 4 }); // ACCC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 4 }, { 'I', 3 } };
+    this->check_edits(path, reference, truth, "mismatch + insertion");
+  }
+
+  // Mismatch + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 2, 1, 3 }); // CAAA
+    gbwt::vector_type reference = forward_path({ 6, 1, 6 }); // CACACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 4 }, { 'D', 3 } };
+    this->check_edits(path, reference, truth, "mismatch + deletion");
+  }
+
+  // Insertion + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 3, 2, 5, 5 }); // AACACAACA
+    gbwt::vector_type reference = forward_path({ 1, 1, 4, 2, 1, 6, 2 }); // AACCCACACCC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 3 }, { 'I', 6 }, { 'D', 7 } };
+    this->check_edits(path, reference, truth, "insertion + deletion");
+  }
+}
+
+TEST_F(AlignDivergingTest, WithPrefixWithSuffix)
+{
+  // Insertion.
+  {
+    gbwt::vector_type path = forward_path({ 5, 2, 5 }); // ACACACA
+    gbwt::vector_type reference = forward_path({ 1, 4, 1 }); // ACCA
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'I', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "insertion");
+  }
+
+  // Deletion.
+  {
+    gbwt::vector_type path = forward_path({ 2, 3, 2 }); // CAAC
+    gbwt::vector_type reference = forward_path({ 6, 1, 6 }); // CACACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'D', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "deletion");
+  }
+
+  // Mismatch + insertion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 2, 4, 6, 2, 1 }); // ACCCCACCA
+    gbwt::vector_type reference = forward_path({ 5, 5 }); // ACAACA
+    std::vector<std::pair<char, size_t>> truth { { 'M', 4 }, { 'I', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "mismatch + insertion");
+  }
+
+  // Mismatch + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 2, 3, 3, 2 }); // CAAAAC
+    gbwt::vector_type reference = forward_path({ 2, 5, 3, 6 }); // CACAAACAC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 4 }, { 'D', 3 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "mismatch + deletion");
+  }
+
+  // Insertion + deletion.
+  {
+    gbwt::vector_type path = forward_path({ 1, 5, 4, 3, 4 }); // AACACCAACC
+    gbwt::vector_type reference = forward_path({ 3, 1, 5, 1, 4, 2 }); // AAAACAACCC
+    std::vector<std::pair<char, size_t>> truth { { 'M', 2 }, { 'I', 6 }, { 'D', 6 }, { 'M', 2 } };
+    this->check_edits(path, reference, truth, "insertion + deletion");
+  }
+}
+
+//------------------------------------------------------------------------------
+
 class SubgraphQueryTest : public ::testing::Test
 {
 public:

--- a/tests/test_subgraph.cpp
+++ b/tests/test_subgraph.cpp
@@ -107,11 +107,14 @@ class SubgraphQueryTest : public ::testing::Test
 public:
   std::vector<std::string> graphs;
   std::vector<std::string> reference_samples;
+  std::vector<size_t> reference_haplotypes;
 
   SubgraphQueryTest()
   {
+    // FIXME add tests with a fragmented reference
     this->graphs = { "gfas/default.gfa", "gfas/components_ref.gfa" };
     this->reference_samples = { REFERENCE_PATH_SAMPLE_NAME, "ref" };
+    this->reference_haplotypes = { GBWTGraph::NO_PHASE, 0 };
   }
 
   void find_path(const GBZ& gbz, size_t graph_number, const std::string& contig_name, path_handle_t& out) const
@@ -189,9 +192,8 @@ TEST_F(SubgraphQueryTest, AllHaplotypes)
   for(size_t i = 0; i < this->graphs.size(); i++)
   {
     GBZ gbz = build_gbz(this->graphs[i]);
-    path_handle_t ref_path;
-    this->find_path(gbz, i, contig_name, ref_path);
-    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::all_haplotypes);
+    gbwt::FullPathName path_name { this->reference_samples[i], contig_name, this->reference_haplotypes[i], 0 };
+    SubgraphQuery query = SubgraphQuery::path_offset(path_name, offset, context, SubgraphQuery::all_haplotypes);
     Subgraph subgraph = this->find_subgraph(gbz, query);
     this->check_subgraph(gbz, i, subgraph, query, nodes, path_count);
 
@@ -239,9 +241,8 @@ TEST_F(SubgraphQueryTest, DistinctHaplotypes)
   for(size_t i = 0; i < this->graphs.size(); i++)
   {
     GBZ gbz = build_gbz(this->graphs[i]);
-    path_handle_t ref_path;
-    this->find_path(gbz, i, contig_name, ref_path);
-    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::distinct_haplotypes);
+    gbwt::FullPathName path_name { this->reference_samples[i], contig_name, this->reference_haplotypes[i], 0 };
+    SubgraphQuery query = SubgraphQuery::path_offset(path_name, offset, context, SubgraphQuery::distinct_haplotypes);
     Subgraph subgraph = this->find_subgraph(gbz, query);
     this->check_subgraph(gbz, i, subgraph, query, nodes, path_counts[i]);
 
@@ -332,9 +333,8 @@ TEST_F(SubgraphQueryTest, ReferenceOnly)
   for(size_t i = 0; i < this->graphs.size(); i++)
   {
     GBZ gbz = build_gbz(this->graphs[i]);
-    path_handle_t ref_path;
-    this->find_path(gbz, i, contig_name, ref_path);
-    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::reference_only);
+    gbwt::FullPathName path_name { this->reference_samples[i], contig_name, this->reference_haplotypes[i], 0 };
+    SubgraphQuery query = SubgraphQuery::path_offset(path_name, offset, context, SubgraphQuery::reference_only);
     Subgraph subgraph = this->find_subgraph(gbz, query);
     this->check_subgraph(gbz, i, subgraph, query, nodes, path_count);
 
@@ -380,9 +380,8 @@ TEST_F(SubgraphQueryTest, ContigB)
   for(size_t i = 0; i < this->graphs.size(); i++)
   {
     GBZ gbz = build_gbz(this->graphs[i]);
-    path_handle_t ref_path;
-    this->find_path(gbz, i, contig_name, ref_path);
-    SubgraphQuery query = SubgraphQuery::path_offset(ref_path, offset, context, SubgraphQuery::distinct_haplotypes);
+    gbwt::FullPathName path_name { this->reference_samples[i], contig_name, this->reference_haplotypes[i], 0 };
+    SubgraphQuery query = SubgraphQuery::path_offset(path_name, offset, context, SubgraphQuery::distinct_haplotypes);
     Subgraph subgraph = this->find_subgraph(gbz, query);
     this->check_subgraph(gbz, i, subgraph, query, nodes, path_counts[i]);
 


### PR DESCRIPTION
Various improvements to subgraph queries that have already been implemented in GBZ-base.

* Allow queries based on offsets/intervals on fragmented reference haplotypes.
* For CIGAR strings relative to the reference path:
  * Use a variant of Myers' O(nd) algorithm for finding a weighted LCS of two paths.
  * Align diverging subpaths roughly according to the alignment scoring used in vg.