### PR TITLE
Increment minimizer index version

### DIFF
--- a/include/gbwtgraph/minimizer.h
+++ b/include/gbwtgraph/minimizer.h
@@ -994,9 +994,6 @@ struct MinimizerHeader
   constexpr static std::uint64_t FLAG_WEIGHT_MASK   = 0x0E00;
   constexpr static size_t        FLAG_WEIGHT_OFFSET = 9;
 
-  // For older compatible versions.
-  constexpr static std::uint32_t V8_VERSION   = 8;
-  constexpr static std::uint64_t V8_FLAG_MASK = 0x1FFF;
 
   MinimizerHeader();
   MinimizerHeader(size_t kmer_length, size_t window_length, size_t key_bits);
@@ -1106,6 +1103,9 @@ struct MinimizerHeader
 
     9  Option to provide a set of frequent kmers that should be avoided as minimizers.
        The capacity field in the header is no longer in use. Compatible with version 8.
+
+   10  Replace the old distance index payload with zipcodes.
+       Not compatible with earlier versions.
 */
 
 template<class KeyType, class ValueType>
@@ -1227,7 +1227,6 @@ public:
       std::cerr << "MinimizerIndex::deserialize(): Expected " << KeyType::KEY_BITS << "-bit keys, got " << this->header.key_bits() << "-bit keys" << std::endl;
       return false;
     }
-    bool has_frequent_kmers = (header.version != MinimizerHeader::V8_VERSION);
     this->header.update_version();
     this->header.fill_statistics(this->index);
 
@@ -1245,8 +1244,8 @@ public:
       }
     }
 
-    // Load the frequent kmers if the index version has them.
-    if(ok && has_frequent_kmers)
+    // Load the frequent kmers.
+    if(ok)
     {
       ok &= io::load_vector(in, this->index.frequent_kmers);
     }

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -136,7 +136,7 @@ struct Version
 
   constexpr static size_t GBZ_VERSION       = 1;
   constexpr static size_t GRAPH_VERSION     = 3;
-  constexpr static size_t MINIMIZER_VERSION = 9;
+  constexpr static size_t MINIMIZER_VERSION = 10;
 
   const static std::string SOURCE_KEY; // source
   const static std::string SOURCE_VALUE; // jltsiren/gbwtgraph

--- a/src/minimizer.cpp
+++ b/src/minimizer.cpp
@@ -199,9 +199,6 @@ constexpr std::uint64_t MinimizerHeader::FLAG_WEIGHT_MASK;
 constexpr size_t MinimizerHeader::FLAG_WEIGHT_OFFSET;
 constexpr std::uint64_t MinimizerHeader::FLAG_SYNCMERS;
 
-constexpr std::uint32_t MinimizerHeader::V8_VERSION;
-constexpr std::uint64_t MinimizerHeader::V8_FLAG_MASK;
-
 //------------------------------------------------------------------------------
 
 // Position: Numerical class constants.
@@ -312,13 +309,13 @@ MinimizerHeader::check() const
     throw sdsl::simple_sds::InvalidData("MinimizerHeader: Invalid tag");
   }
 
-  if(this->version < V8_VERSION || this->version > VERSION)
+  if(this->version < VERSION || this->version > VERSION)
   {
-    std::string msg = "MinimizerHeader: Expected v" + std::to_string(V8_VERSION) + " to " + std::to_string(VERSION) + ", got v" + std::to_string(this->version);
+    std::string msg = "MinimizerHeader: Expected v" + std::to_string(VERSION) + ", got v" + std::to_string(this->version);
     throw sdsl::simple_sds::InvalidData(msg);
   }
 
-  std::uint64_t mask = (this->version == V8_VERSION ? V8_FLAG_MASK : FLAG_MASK);
+  std::uint64_t mask = (FLAG_MASK);
   if((this->flags & mask) != this->flags)
   {
     throw sdsl::simple_sds::InvalidData("MinimizerHeader: Invalid flags");


### PR DESCRIPTION
I incremented the minimizer index version to version 10.
Technically the older versions still work as long as they don't use the payload.

This probably shouldn't be merged until we merge [long read giraffe](https://github.com/vgteam/vg/pull/4323) into vg