### PR TITLE
GBZ chunking / merging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ HEADERS=$(wildcard include/gbwtgraph/*.h)
 LIBOBJS=$(addprefix $(BUILD_OBJ)/,algorithms.o cached_gbwtgraph.o gbwtgraph.o gbz.o gfa.o index.o internal.o minimizer.o naive_graph.o path_cover.o subgraph.o utils.o)
 LIBRARY=$(BUILD_LIB)/libgbwtgraph.a
 
-PROGRAMS=$(addprefix $(BUILD_BIN)/,canonical_gfa gfa2gbwt gbz_extract gbz_stats kmer_freq subgraph_query)
+PROGRAMS=$(addprefix $(BUILD_BIN)/,canonical_gfa chunk_gbz gfa2gbwt gbz_extract gbz_stats kmer_freq subgraph_query)
 OBSOLETE=gfa2gbwt
 
 .PHONY: all clean directories test

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The package also includes:
 
 * [GBZ file format](https://github.com/jltsiren/gbwtgraph/blob/master/SERIALIZATION.md).
 * GBWT / GBWTGraph construction from a subset of GFA1, and GFA extraction from a GBWTGraph.
-* A generic kmer index and a generic minimizer index for indexing the haplotypes in the GBWTGraph.
 * GBWT construction from a greedy path cover:
   * Artificial paths that try to cover all length-k contexts equally, either in the entire graph or only in components that do not already contain paths.
   * Concatenations of local length-k haplotypes sampled according to their true frequencies.
@@ -42,6 +41,10 @@ The package also includes:
   * `gbwt_construction_jobs()` for determining the construction jobs.
   * `assign_paths()` and `insert_paths()` for passing reference paths to the new GBWT.
   * `MetadataBuilder` for generating GBWT metadata.
+* Tools for extracting per-chromosome graphs and merging them:
+  * Chunk graphs by weakly connected components and extract chunks by contig names using `chunk_graph()`.
+  * Merging non-overlapping subgraphs with the GBZ merge constructor.
+* A generic kmer index and a generic minimizer index for indexing the haplotypes in the GBWTGraph.
 
 ## Construction from GFA
 

--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -64,11 +64,9 @@ struct ChunkParameters
 };
 
 // FIXME: split the GBWT directly. Use the DASamples(RecordArray, samples) constructor to avoid unnecessary complexity
-// FIXME: test
-// FIXME: return a pair of vectors?
 /*
   Partition the graph into chunks based on the weakly connected components.
-  Returns a contig name and a GBZ graph for each chunk, ordered by minimum node
+  Returns a GBZ graph and a contig name for each chunk, ordered by minimum node
   id in each chunk. Uses `ConstructionJobs::contig_names()` to determine the
   contig name for each chunk.
 
@@ -76,7 +74,7 @@ struct ChunkParameters
   with the given contig name, or an empty vector if no such paths exist. The
   contig names reported in the result may be different from the given name.
 */
-std::vector<std::pair<std::string, GBZ>> chunk_graph(const GBZ& gbz, const ChunkParameters& params);
+std::pair<std::vector<GBZ>, std::vector<std::string>> chunk_graph(const GBZ& gbz, const ChunkParameters& params);
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -56,14 +56,10 @@ struct ChunkParameters
   // If not empty, output only the chunk(s) containing this contig name.
   std::string contig_name;
 
-  // Build chunks for this many components in parallel.
-  size_t parallel_jobs = 1;
-
   // Print progress information during chunking.
   bool verbose = false;
 };
 
-// FIXME: split the GBWT directly. Use the DASamples(RecordArray, samples) constructor to avoid unnecessary complexity
 /*
   Partition the graph into chunks based on the weakly connected components.
   Returns a GBZ graph and a contig name for each chunk, ordered by minimum node

--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -65,6 +65,7 @@ struct ChunkParameters
 
 // FIXME: split the GBWT directly. Use the DASamples(RecordArray, samples) constructor to avoid unnecessary complexity
 // FIXME: test
+// FIXME: return a pair of vectors?
 /*
   Partition the graph into chunks based on the weakly connected components.
   Returns a contig name and a GBZ graph for each chunk, ordered by minimum node

--- a/include/gbwtgraph/algorithms.h
+++ b/include/gbwtgraph/algorithms.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <gbwtgraph/gbwtgraph.h>
+#include <gbwtgraph/gbz.h>
 
 #include <gbwt/dynamic_gbwt.h>
 
@@ -47,6 +47,35 @@ std::vector<nid_t> is_nice_and_acyclic(const HandleGraph& graph, const std::vect
   GBWTGraph.
 */
 std::vector<handle_t> topological_order(const HandleGraph& graph, const std::unordered_set<nid_t>& subgraph);
+
+//------------------------------------------------------------------------------
+
+// Parameters for `chunk_graph()`.
+struct ChunkParameters
+{
+  // If not empty, output only the chunk(s) containing this contig name.
+  std::string contig_name;
+
+  // Build chunks for this many components in parallel.
+  size_t parallel_jobs = 1;
+
+  // Print progress information during chunking.
+  bool verbose = false;
+};
+
+// FIXME: split the GBWT directly. Use the DASamples(RecordArray, samples) constructor to avoid unnecessary complexity
+// FIXME: test
+/*
+  Partition the graph into chunks based on the weakly connected components.
+  Returns a contig name and a GBZ graph for each chunk, ordered by minimum node
+  id in each chunk. Uses `ConstructionJobs::contig_names()` to determine the
+  contig name for each chunk.
+
+  If `params.contig_name` is set, returns only the chunk(s) containing a path
+  with the given contig name, or an empty vector if no such paths exist. The
+  contig names reported in the result may be different from the given name.
+*/
+std::vector<std::pair<std::string, GBZ>> chunk_graph(const GBZ& gbz, const ChunkParameters& params);
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -66,9 +66,11 @@ public:
   GBWTGraph(const gbwt::GBWT& gbwt_index, const HandleGraph& graph, const NamedNodeBackTranslation* segment_space);
 
   // Returns a GBWTGraph for the subgraph defined by the given GBWT index.
+  // Updates the given GBWT index to have the same reference samples as this graph,
+  // if they exist in the metadata.
   // The returned graph will not have a node-to-segment translation.
   // This is faster than using the graph as a HandleGraph in the constructor.
-  GBWTGraph subgraph(const gbwt::GBWT& gbwt_index) const;
+  GBWTGraph subgraph(gbwt::GBWT& gbwt_index) const;
 
   // Makes some sanity checks on the internal consistency of the structure.
   // Requires that the GBWT index has been set.

--- a/include/gbwtgraph/gbwtgraph.h
+++ b/include/gbwtgraph/gbwtgraph.h
@@ -136,7 +136,7 @@ public:
   std::vector<NamedPath>                      named_paths;
   std::unordered_map<std::string, size_t>     name_to_path; // To offset in `named_paths`.
   std::unordered_map<gbwt::size_type, size_t> id_to_path; // To offset in `named_paths`.
-  std::unordered_set<std::string>             reference_samples; // Parsed from tags in the GBWT.
+  sample_name_set                             reference_samples; // Parsed from tags in the GBWT.
   // Path handles are either indexes into named_paths, or, if larger than
   // named_paths, are an offset of the size of named_paths plus a path number in
   // our metadata object. This syntactically allows for aliasing: cached paths

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -49,8 +49,8 @@ public:
   // Moves the subgraphs out of the provided vector.
   // Fails with `std::exit()` if the graphs have overlapping node ids.
   // Sets the union of reference samples in the GBWT indexes as reference
-  // samples. Does not create a node-to-segment translation. Calls
-  // compute_pggname() internally.
+  // samples. Does not create a node-to-segment translation.
+  // Calls compute_pggname() internally but does not set any relationships.
   explicit GBZ(std::vector<GBZ>&& subgraphs);
 
   // Builds a GBZ from a GBWT index and a GBZ supergraph.
@@ -128,11 +128,11 @@ public:
   // Sets the given sample names as reference samples, but only if they are
   // present in the GBWT metadata. Returns the number of reference samples.
   // This is somewhat expensive, as the GBWTGraph must recache named paths.
-  size_t set_reference_samples(const std::unordered_set<std::string>& samples);
+  size_t set_reference_samples(const sample_name_set& samples);
 
   // Returns the set of reference samples.
   // Some of these samples may not exist in the GBWT metadata.
-  const std::unordered_set<std::string>& get_reference_samples() const
+  const sample_name_set& get_reference_samples() const
   {
     return this->graph.reference_samples;
   }

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -29,7 +29,9 @@ namespace gbwtgraph
 class GBZ
 {
 public:
+  // This is a valid graph, unlike the default GBWTGraph.
   GBZ();
+
   GBZ(const GBZ& source);
   GBZ(GBZ&& source);
   ~GBZ();

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -43,6 +43,14 @@ public:
   // copy of the GBWT index. Mostly for testing.
   GBZ(const gbwt::GBWT& index, const NaiveGraph& graph);
 
+  // Builds GBZ from a set of non-overlapping subgraphs.
+  // Moves the subgraphs out of the provided vector.
+  // Fails with `std::exit()` if the graphs have overlapping node ids.
+  // Sets the union of reference samples in the GBWT indexes as reference
+  // samples. Does not create a node-to-segment translation. Calls
+  // compute_pggname() internally.
+  explicit GBZ(std::vector<GBZ>&& subgraphs);
+
   // Builds a GBZ from a GBWT index and a GBZ supergraph.
   // Reference samples in the supergraph that are present in the GBWT
   // index will be set as reference samples. Calls compute_pggname()

--- a/include/gbwtgraph/gbz.h
+++ b/include/gbwtgraph/gbz.h
@@ -44,8 +44,9 @@ public:
   GBZ(const gbwt::GBWT& index, const NaiveGraph& graph);
 
   // Builds a GBZ from a GBWT index and a GBZ supergraph.
-  // Calls compute_pggname() internally. The provided GBWT index will be
-  // moved into the GBZ.
+  // Reference samples in the supergraph that are present in the GBWT
+  // index will be set as reference samples. Calls compute_pggname()
+  // internally. The provided GBWT index will be moved into the GBZ.
   GBZ(gbwt::GBWT&& index, const GBZ& supergraph);
 
   // Build GBZ from a GBWT index and a `HandleGraph`, with an optional

--- a/include/gbwtgraph/path_cover.h
+++ b/include/gbwtgraph/path_cover.h
@@ -119,7 +119,8 @@ struct PathCoverParameters
 
   NOTE: The resulting GBWT does not have any samples assigned as reference samples. If
   reference paths were included, the REFERENCE_SAMPLE_LIST_GBWT_TAG tag should be set
-  separately when appropriate.
+  separately when appropriate. However, the subgraph constructors for GBWTGraph and GBZ
+  will do this automatically.
 */
 gbwt::GBWT path_cover_gbwt(
   const PathHandleGraph& graph,
@@ -144,7 +145,8 @@ gbwt::GBWT path_cover_gbwt(
 
   NOTE: The resulting GBWT does not have any samples assigned as reference samples. If
   reference paths were included, the REFERENCE_SAMPLE_LIST_GBWT_TAG tag should be set
-  separately when appropriate.
+  separately when appropriate. However, the subgraph constructors for GBWTGraph and GBZ
+  will do this automatically.
 */
 gbwt::GBWT local_haplotypes(
   const PathHandleGraph& graph,

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -168,22 +168,23 @@ struct Version
 
 //------------------------------------------------------------------------------
 
-// FIXME: We should use set instead of unordered_set to guarantee consistent behavior.
+// Keep the sample names in order to guarantee consistent conversions between tags and sets.
+typedef std::set<std::string> sample_name_set;
 
 // Parse a path sense tag value to a collection of reference-sense sample names.
-std::unordered_set<std::string> parse_reference_samples_tag(const char* cursor, const char* end);
+sample_name_set parse_reference_samples_tag(const char* cursor, const char* end);
 
 // Parse a path sense tag value to a collection of reference-sense sample names.
-std::unordered_set<std::string> parse_reference_samples_tag(std::string_view tag_value);
+sample_name_set parse_reference_samples_tag(std::string_view tag_value);
 
 // Parse the reference samples tag embedded in a GBWT index.
-std::unordered_set<std::string> parse_reference_samples_tag(const gbwt::GBWT& index);
+sample_name_set parse_reference_samples_tag(const gbwt::GBWT& index);
 
 // Returns the subset of the given sample names that are present in the given GBWT index.
-std::unordered_set<std::string> present_sample_names(const std::unordered_set<std::string>& sample_names, const gbwt::GBWT& index);
+sample_name_set present_sample_names(const sample_name_set& sample_names, const gbwt::GBWT& index);
 
 // Compose a reference sample name tag from a collection of reference-sense sample names.
-std::string compose_reference_samples_tag(const std::unordered_set<std::string>& reference_samples);
+std::string compose_reference_samples_tag(const sample_name_set& reference_samples);
 
 //------------------------------------------------------------------------------
 
@@ -196,20 +197,20 @@ std::string compose_reference_samples_tag(const std::unordered_set<std::string>&
 // Takes a reference path set from parse_reference_samples_tag, and handles identifying
 // the string sample name and defaulting un-mentioned samples.
 // Tolerates incomplete metadata.
-PathSense get_path_sense(const gbwt::Metadata& metadata, const gbwt::PathName& path_name, const std::unordered_set<std::string>& reference_samples);
+PathSense get_path_sense(const gbwt::Metadata& metadata, const gbwt::PathName& path_name, const sample_name_set& reference_samples);
 
 // Determine the sense a path ought to have, given an index and the reference
 // samples set parsed from it with parse_reference_samples_tag.
 // Tolerates missing metadata.
-PathSense get_path_sense(const gbwt::GBWT& index, gbwt::size_type path_number, const std::unordered_set<std::string>& reference_samples);
+PathSense get_path_sense(const gbwt::GBWT& index, gbwt::size_type path_number, const sample_name_set& reference_samples);
 
 // Determine the sense that paths for a sample ought to have, given the sample number.
 // Tolerates incomplete metadata.
-PathSense get_sample_sense(const gbwt::Metadata& metadata, gbwt::size_type sample, const std::unordered_set<std::string>& reference_samples);
+PathSense get_sample_sense(const gbwt::Metadata& metadata, gbwt::size_type sample, const sample_name_set& reference_samples);
 
 // Determine the sense that paths for a sample ought to have, given the string sample name.
 // The metadata is assumed to be populated with sample names.
-PathSense get_sample_sense(const std::string& sample_name, const std::unordered_set<std::string>& reference_samples);
+PathSense get_sample_sense(const std::string& sample_name, const sample_name_set& reference_samples);
 
 // Determine the sample name that a path ought to present, from stored metadata.
 // Tolerates incomplete metadata.

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -180,6 +180,9 @@ std::unordered_set<std::string> parse_reference_samples_tag(std::string_view tag
 // Parse the reference samples tag embedded in a GBWT index.
 std::unordered_set<std::string> parse_reference_samples_tag(const gbwt::GBWT& index);
 
+// Returns the subset of the given sample names that are present in the given GBWT index.
+std::unordered_set<std::string> present_sample_names(const std::unordered_set<std::string>& sample_names, const gbwt::GBWT& index);
+
 // Compose a reference sample name tag from a collection of reference-sense sample names.
 std::string compose_reference_samples_tag(const std::unordered_set<std::string>& reference_samples);
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -638,6 +638,9 @@ public:
   // Add a path based on GFA walk metadata and assign it to the given job.
   void add_walk(const std::string& sample, const std::string& haplotype, const std::string& contig, const std::string& start, size_t job = 0);
 
+  // Add a GBWT path and assign it to the given job.
+  void add_gbwt_path(const gbwt::FullPathName& path_name, size_t job = 0);
+
   // Add a haplotype path and assign it to the given job.
   void add_haplotype(const std::string& sample, const std::string& contig, size_t haplotype, size_t fragment, size_t job = 0);
 

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -168,15 +168,14 @@ struct Version
 
 //------------------------------------------------------------------------------
 
-// Because we want to be able to work with path metadata with just the GBWT, we
-// expose the utility functions for dealing with it. The packing format only
-// has to touch these functions and MetadataBuilder, and some of the GBWTGraph
-// search methods.
+// FIXME: We should use set instead of unordered_set to guarantee consistent behavior.
 
 // Parse a path sense tag value to a collection of reference-sense sample names.
 std::unordered_set<std::string> parse_reference_samples_tag(const char* cursor, const char* end);
+
 // Parse a path sense tag value to a collection of reference-sense sample names.
 std::unordered_set<std::string> parse_reference_samples_tag(std::string_view tag_value);
+
 // Parse the reference samples tag embedded in a GBWT index.
 std::unordered_set<std::string> parse_reference_samples_tag(const gbwt::GBWT& index);
 
@@ -185,6 +184,13 @@ std::unordered_set<std::string> present_sample_names(const std::unordered_set<st
 
 // Compose a reference sample name tag from a collection of reference-sense sample names.
 std::string compose_reference_samples_tag(const std::unordered_set<std::string>& reference_samples);
+
+//------------------------------------------------------------------------------
+
+// Because we want to be able to work with path metadata with just the GBWT, we
+// expose the utility functions for dealing with it. The packing format only
+// has to touch these functions and MetadataBuilder, and some of the GBWTGraph
+// search methods.
 
 // Determine the sense that a path ought to have, from stored metadata.
 // Takes a reference path set from parse_reference_samples_tag, and handles identifying

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -2,7 +2,6 @@
 
 #include <limits>
 #include <map>
-#include <set>
 #include <stack>
 #include <unordered_map>
 
@@ -252,103 +251,100 @@ chunk_graph(const GBZ& gbz, const ChunkParameters& params)
     std::cerr << "Chunking the graph" << std::endl;
   }
 
-  // Find the weakly connected components, guess reference contig names, and assign paths to components.
+  // Find the weakly connected components.
   ConstructionJobs jobs = gbwt_construction_jobs(gbz.graph, 1);
   std::vector<std::string> contig_names = jobs.contig_names(gbz.graph);
-  std::vector<size_t> path_to_component(gbz.index.metadata.paths(), jobs.components());
-  std::vector<std::vector<gbwt::size_type>> paths_for_component(jobs.components());
-  for(gbwt::size_type path_id = 0; path_id < gbz.index.metadata.paths(); path_id++)
-  {
-    gbwt::edge_type start = gbz.index.start(gbwt::Path::encode(path_id, false));
-    size_t component_id = jobs.component(gbwt::Node::id(start.first));
-    path_to_component[path_id] = component_id;
-    if(component_id < jobs.components()) { paths_for_component[component_id].push_back(path_id); }
-  }
   if(params.verbose)
   {
-    std::cerr << "Assigned " << gbz.index.metadata.paths() << " paths to " << jobs.components() << " components" << std::endl;
+    std::cerr << "Found " << jobs.components() << " weakly connected components" << std::endl;
   }
 
-  // Determine the components we want to extract.
-  std::vector<size_t> selected_components;
-  if(params.contig_name.empty())
-  {
-    for(size_t i = 0; i < jobs.components(); i++) { selected_components.push_back(i); }
-  }
-  else
+  // Determine the components we want to extract, or leave it empty to extract all of them.
+  std::map<size_t, size_t> selected_components; // (original component id, selected component rank)
+  if(!params.contig_name.empty())
   {
     // The given contig name may not be for a reference path.
     gbwt::size_type contig_id = gbz.index.metadata.contig(params.contig_name);
     auto path_ids = gbz.index.metadata.pathsForContig(contig_id);
-    std::set<size_t> selected;
     for(gbwt::size_type path_id : path_ids)
     {
-      size_t component_id = path_to_component[path_id];
-      if(component_id < jobs.components()) { selected.insert(component_id); }
+      gbwt::edge_type start = gbz.index.start(gbwt::Path::encode(path_id, false));
+      size_t component_id = jobs.component(gbwt::Node::id(start.first));
+      if(component_id < jobs.components())
+      {
+        // We cannot use operator[], as that would increase the size before we access it.
+        selected_components.insert(std::make_pair(component_id, selected_components.size()));
+      }
     }
-    selected_components.assign(selected.begin(), selected.end());
+    if(params.verbose)
+    {
+      std::cerr << "Selected " << selected_components.size() << " components for contig " << params.contig_name << std::endl;
+    }
+    if(selected_components.empty())
+    {
+      return std::pair<std::vector<GBZ>, std::vector<std::string>>();
+    }
   }
+
+  // Split the GBWT.
+  size_t components = (selected_components.empty() ? jobs.components() : selected_components.size());
+  auto node_to_component = [&](gbwt::node_type node) -> gbwt::size_type
+  {
+    nid_t id = gbwt::Node::id(node);
+    size_t component_id = jobs.component(id);
+    if(selected_components.empty())
+    {
+      return component_id;
+    }
+    auto iter = selected_components.find(component_id);
+    if(iter != selected_components.end())
+    {
+      return iter->second;
+    }
+    else
+    {
+      // Skip this node.
+      return components;
+    }
+  };
+  std::vector<gbwt::GBWT> component_gbwts = gbz.index.split(components, node_to_component);
   if(params.verbose)
   {
-    std::cerr << "Selected " << selected_components.size() << " components" << std::endl;
+    std::cerr << "Split the GBWT into " << component_gbwts.size() << " parts" << std::endl;
   }
 
+  // Initialize the result.
   std::pair<std::vector<GBZ>, std::vector<std::string>> result;
-  result.first.reserve(selected_components.size());
-  result.second.reserve(selected_components.size());
-  for(size_t i = 0; i < selected_components.size(); i++)
+  result.first.reserve(components);
+  result.second.reserve(components);
+  if(selected_components.empty())
   {
-    result.first.emplace_back();
-    result.second.emplace_back(contig_names[selected_components[i]]);
+    for(size_t i = 0; i < components; i++)
+    {
+      result.second.emplace_back(contig_names[i]);
+    }
+  }
+  else
+  {
+    size_t index = 0;
+    for(auto iter = selected_components.begin(); iter != selected_components.end(); ++iter, index++)
+    {
+      result.second.emplace_back(contig_names[iter->first]);
+    }
   }
 
-  // And now build the GBZs.
-  size_t threads = std::max(size_t(1), params.parallel_jobs);
-  gbwt::size_type width = sdsl::bits::length(gbz.index.sigma() - 1);
+  // And now build the GBZs. Note that we need to pass the reference samples manually,
+  // as the GBWT library does not know about them.
   auto ref_samples = parse_reference_samples_tag(gbz.index);
-  int old_threads = omp_get_max_threads();
-  omp_set_num_threads(threads);
-  #pragma omp parallel for schedule(dynamic, 1)
-  for(size_t i = 0; i < selected_components.size(); i++)
+  for(size_t i = 0; i < components; i++)
   {
-    double job_start = gbwt::readTimer();
-    size_t component_id = selected_components[i];
-    if(params.verbose)
-    {
-      #pragma omp critical
-      {
-        std::cerr << "Starting job " << i << " (" << contig_names[component_id] << ") with " << paths_for_component[component_id].size() << " paths" << std::endl;
-      }
-    }
-    gbwt::GBWTBuilder builder(width);
-    MetadataBuilder metadata_builder;
-    for(gbwt::size_type path_id : paths_for_component[component_id])
-    {
-      gbwt::vector_type path = gbz.index.extract(gbwt::Path::encode(path_id, false));
-      builder.insert(path, true);
-      gbwt::FullPathName name = gbz.index.metadata.fullPath(path_id);
-      metadata_builder.add_gbwt_path(name);
-    }
-    builder.finish();
-    gbwt::GBWT index(builder.index);
-    index.addMetadata();
-    index.metadata = metadata_builder.get_metadata();
-    auto present_ref_samples = present_sample_names(ref_samples, index);
+    auto present_ref_samples = present_sample_names(ref_samples, component_gbwts[i]);
     if(!present_ref_samples.empty())
     {
-      index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, compose_reference_samples_tag(present_ref_samples));
+      component_gbwts[i].tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, compose_reference_samples_tag(present_ref_samples));
     }
-    result.first[i] = GBZ(std::move(index), gbz);
-    if(params.verbose)
-    {
-      double seconds = gbwt::readTimer() - job_start;
-      #pragma omp critical
-      {
-        std::cerr << "Finished job " << i << " in " << seconds << " seconds" << std::endl;
-      }
-    }
+    result.first.emplace_back(std::move(component_gbwts[i]), gbz);
   }
-  omp_set_num_threads(old_threads);
   if(params.verbose)
   {
     std::cerr << "Extracted " << result.first.size() << " chunks" << std::endl;

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <map>
+#include <set>
 #include <stack>
 #include <unordered_map>
 
@@ -236,6 +237,113 @@ topological_order(const HandleGraph& graph, const std::unordered_set<nid_t>& sub
   }
 
   if(result.size() != 2 * (subgraph.size() - missing_nodes)) { result.clear(); }
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
+std::vector<std::pair<std::string, GBZ>>
+chunk_graph(const GBZ& gbz, const ChunkParameters& params)
+{
+  if(params.verbose)
+  {
+    std::cerr << "Chunking the graph" << std::endl;
+  }
+
+  // Find the weakly connected components, guess reference contig names, and assign paths to components.
+  ConstructionJobs jobs = gbwt_construction_jobs(gbz.graph, 1);
+  std::vector<std::string> contig_names = jobs.contig_names(gbz.graph);
+  std::vector<size_t> path_to_component(gbz.index.metadata.paths(), jobs.components());
+  std::vector<std::vector<gbwt::size_type>> paths_for_component(jobs.components());
+  for(gbwt::size_type path_id = 0; path_id < gbz.index.metadata.paths(); path_id++)
+  {
+    gbwt::edge_type start = gbz.index.start(gbwt::Path::encode(path_id, false));
+    size_t component_id = jobs.component(gbwt::Node::id(start.first));
+    path_to_component[path_id] = component_id;
+    if(component_id < jobs.components()) { paths_for_component[component_id].push_back(path_id); }
+  }
+  if(params.verbose)
+  {
+    std::cerr << "Assigned " << gbz.index.metadata.paths() << " paths to " << jobs.components() << " components" << std::endl;
+  }
+
+  // Determine the components we want to extract.
+  std::vector<size_t> selected_components;
+  if(params.contig_name.empty())
+  {
+    for(size_t i = 0; i < jobs.components(); i++) { selected_components.push_back(i); }
+  }
+  else
+  {
+    // The given contig name may not be for a reference path.
+    gbwt::size_type contig_id = gbz.index.metadata.contig(params.contig_name);
+    auto path_ids = gbz.index.metadata.pathsForContig(contig_id);
+    std::set<size_t> selected;
+    for(gbwt::size_type path_id : path_ids)
+    {
+      size_t component_id = path_to_component[path_id];
+      if(component_id < jobs.components()) { selected.insert(component_id); }
+    }
+    selected_components.assign(selected.begin(), selected.end());
+  }
+  if(params.verbose)
+  {
+    std::cerr << "Selected " << selected_components.size() << " components" << std::endl;
+  }
+
+  std::vector<std::pair<std::string, GBZ>> result;
+  result.reserve(selected_components.size());
+  for(size_t i = 0; i < selected_components.size(); i++)
+  {
+    result.emplace_back(contig_names[selected_components[i]], GBZ());
+  }
+
+  // And now build the GBZs.
+  size_t threads = std::max(size_t(1), params.parallel_jobs);
+  gbwt::size_type width = sdsl::bits::length(gbz.index.sigma() - 1);
+  int old_threads = omp_get_max_threads();
+  omp_set_num_threads(threads);
+  #pragma omp parallel for schedule(dynamic, 1)
+  for(size_t i = 0; i < selected_components.size(); i++)
+  {
+    double job_start = gbwt::readTimer();
+    size_t component_id = selected_components[i];
+    if(params.verbose)
+    {
+      #pragma omp critical
+      {
+        std::cerr << "Starting job " << i << " (" << contig_names[component_id] << ") with " << paths_for_component[component_id].size() << " paths" << std::endl;
+      }
+    }
+    gbwt::GBWTBuilder builder(width);
+    MetadataBuilder metadata_builder;
+    for(gbwt::size_type path_id : paths_for_component[component_id])
+    {
+      gbwt::vector_type path = gbz.index.extract(gbwt::Path::encode(path_id, false));
+      builder.insert(path, true);
+      gbwt::FullPathName name = gbz.index.metadata.fullPath(path_id);
+      metadata_builder.add_gbwt_path(name);
+    }
+    builder.finish();
+    gbwt::GBWT index(builder.index);
+    index.addMetadata();
+    index.metadata = metadata_builder.get_metadata();
+    result[i].second = GBZ(std::move(index), gbz);
+    if(params.verbose)
+    {
+      double seconds = gbwt::readTimer() - job_start;
+      #pragma omp critical
+      {
+        std::cerr << "Finished job " << i << " in " << seconds << " seconds" << std::endl;
+      }
+    }
+  }
+  omp_set_num_threads(old_threads);
+  if(params.verbose)
+  {
+    std::cerr << "Extracted " << result.size() << " chunks" << std::endl;
+  }
+
   return result;
 }
 

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -78,6 +78,8 @@ struct DisjointSets
 std::vector<std::vector<nid_t>>
 weakly_connected_components(const HandleGraph& graph)
 {
+  if(graph.get_node_count() == 0) { return std::vector<std::vector<nid_t>>(); }
+
   nid_t min_id = graph.min_node_id(), max_id = graph.max_node_id();
 
   sdsl::bit_vector found(max_id + 1 - min_id, 0);
@@ -242,7 +244,7 @@ topological_order(const HandleGraph& graph, const std::unordered_set<nid_t>& sub
 
 //------------------------------------------------------------------------------
 
-std::vector<std::pair<std::string, GBZ>>
+std::pair<std::vector<GBZ>, std::vector<std::string>>
 chunk_graph(const GBZ& gbz, const ChunkParameters& params)
 {
   if(params.verbose)
@@ -291,16 +293,19 @@ chunk_graph(const GBZ& gbz, const ChunkParameters& params)
     std::cerr << "Selected " << selected_components.size() << " components" << std::endl;
   }
 
-  std::vector<std::pair<std::string, GBZ>> result;
-  result.reserve(selected_components.size());
+  std::pair<std::vector<GBZ>, std::vector<std::string>> result;
+  result.first.reserve(selected_components.size());
+  result.second.reserve(selected_components.size());
   for(size_t i = 0; i < selected_components.size(); i++)
   {
-    result.emplace_back(contig_names[selected_components[i]], GBZ());
+    result.first.emplace_back();
+    result.second.emplace_back(contig_names[selected_components[i]]);
   }
 
   // And now build the GBZs.
   size_t threads = std::max(size_t(1), params.parallel_jobs);
   gbwt::size_type width = sdsl::bits::length(gbz.index.sigma() - 1);
+  auto ref_samples = parse_reference_samples_tag(gbz.index);
   int old_threads = omp_get_max_threads();
   omp_set_num_threads(threads);
   #pragma omp parallel for schedule(dynamic, 1)
@@ -328,7 +333,12 @@ chunk_graph(const GBZ& gbz, const ChunkParameters& params)
     gbwt::GBWT index(builder.index);
     index.addMetadata();
     index.metadata = metadata_builder.get_metadata();
-    result[i].second = GBZ(std::move(index), gbz);
+    auto present_ref_samples = present_sample_names(ref_samples, index);
+    if(!present_ref_samples.empty())
+    {
+      index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, compose_reference_samples_tag(present_ref_samples));
+    }
+    result.first[i] = GBZ(std::move(index), gbz);
     if(params.verbose)
     {
       double seconds = gbwt::readTimer() - job_start;
@@ -341,7 +351,7 @@ chunk_graph(const GBZ& gbz, const ChunkParameters& params)
   omp_set_num_threads(old_threads);
   if(params.verbose)
   {
-    std::cerr << "Extracted " << result.size() << " chunks" << std::endl;
+    std::cerr << "Extracted " << result.first.size() << " chunks" << std::endl;
   }
 
   return result;

--- a/src/chunk_gbz.cpp
+++ b/src/chunk_gbz.cpp
@@ -72,7 +72,6 @@ printUsage(int exit_code)
   std::cerr << std::endl;
   std::cerr << "Options:" << std::endl;
   std::cerr << "  -c, --contig X  only extract components with this contig name" << std::endl;
-  std::cerr << "  -j, --jobs N    run this many parallel jobs (default: 1)" << std::endl;
   std::cerr << "  -p, --prefix X  use this output prefix (default: " << default_prefix << ")" << std::endl;
   std::cerr << "  -v, --verbose   print progress information" << std::endl;
   std::cerr << std::endl;
@@ -91,27 +90,18 @@ Config::Config(int argc, char** argv)
   option long_options[] =
   {
     { "contig", required_argument, nullptr, 'c' },
-    { "jobs", required_argument, nullptr, 'j' },
     { "prefix", required_argument, nullptr, 'p' },
     { "verbose", no_argument, nullptr, 'v' },
     { 0, 0, 0, 0 }
   };
 
   // Process options.
-  while((c = getopt_long(argc, argv, "c:j:p:v", long_options, &option_index)) != -1)
+  while((c = getopt_long(argc, argv, "c:p:v", long_options, &option_index)) != -1)
   {
     switch(c)
     {
     case 'c':
       this->params.contig_name = optarg;
-      break;
-    case 'j':
-      try { this->params.parallel_jobs = std::stoul(optarg); }
-      catch(std::exception& e)
-      {
-        std::cerr << "Cannot parse --jobs " << optarg << ": " << e.what() << std::endl;
-        std::exit(EXIT_FAILURE);
-      }
       break;
     case 'p':
       this->output_prefix = optarg;

--- a/src/chunk_gbz.cpp
+++ b/src/chunk_gbz.cpp
@@ -1,0 +1,135 @@
+#include <iostream>
+#include <fstream>
+
+#include <getopt.h>
+#include <unistd.h>
+
+#include <gbwtgraph/algorithms.h>
+
+using namespace gbwtgraph;
+
+//------------------------------------------------------------------------------
+
+const std::string tool_name = "Chunk GBZ";
+const std::string default_prefix = "chunk";
+
+struct Config
+{
+  Config(int argc, char** argv);
+
+  std::string input;
+  std::string output_prefix = default_prefix;
+
+  ChunkParameters params;
+};
+
+//------------------------------------------------------------------------------
+
+int
+main(int argc, char** argv)
+{
+  double start = gbwt::readTimer();
+  Config config(argc, argv);
+
+  GBZ gbz;
+  if(config.params.verbose)
+  {
+    std::cerr << "Loading the graph from " << config.input << std::endl;
+  }
+  sdsl::simple_sds::load_from(gbz, config.input);
+
+  std::vector<std::pair<std::string, GBZ>> chunks = chunk_graph(gbz, config.params);
+
+  if(config.params.verbose)
+  {
+    std::cerr << "Writing the output files" << std::endl;
+  }
+  for(size_t i = 0; i < chunks.size(); i++)
+  {
+    std::string filename = config.output_prefix + "_" + std::to_string(i) + "_" + chunks[i].first + ".gbz";
+    sdsl::simple_sds::serialize_to(chunks[i].second, filename);
+  }
+
+  if(config.params.verbose)
+  {
+    double seconds = gbwt::readTimer() - start;
+    std::cerr << "Used " << seconds << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GiB" << std::endl;
+  }
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void
+printUsage(int exit_code)
+{
+  Version::print(std::cerr, tool_name);
+
+  std::cerr << "Usage: chunk_gbz [options] graph.gbz" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "Chunks the given graph into weakly connected components." << std::endl;
+  std::cerr << "Output files are named <prefix>_<index>_<contig>.gbz." << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "Options:" << std::endl;
+  std::cerr << "  -c, --contig X  only extract components with this contig name" << std::endl;
+  std::cerr << "  -j, --jobs N    run this many parallel jobs (default: 1)" << std::endl;
+  std::cerr << "  -p, --prefix X  use this output prefix (default: " << default_prefix << ")" << std::endl;
+  std::cerr << "  -v, --verbose   print progress information" << std::endl;
+  std::cerr << std::endl;
+
+  std::exit(exit_code);
+}
+
+//------------------------------------------------------------------------------
+
+Config::Config(int argc, char** argv)
+{
+  if(argc < 2) { printUsage(EXIT_SUCCESS); }
+
+  // Data for `getopt_long()`.
+  int c = 0, option_index = 0;
+  option long_options[] =
+  {
+    { "contig", required_argument, nullptr, 'c' },
+    { "jobs", required_argument, nullptr, 'j' },
+    { "prefix", required_argument, nullptr, 'p' },
+    { "verbose", no_argument, nullptr, 'v' },
+    { 0, 0, 0, 0 }
+  };
+
+  // Process options.
+  while((c = getopt_long(argc, argv, "c:j:p:v", long_options, &option_index)) != -1)
+  {
+    switch(c)
+    {
+    case 'c':
+      this->params.contig_name = optarg;
+      break;
+    case 'j':
+      try { this->params.parallel_jobs = std::stoul(optarg); }
+      catch(std::exception& e)
+      {
+        std::cerr << "Cannot parse --jobs " << optarg << ": " << e.what() << std::endl;
+        std::exit(EXIT_FAILURE);
+      }
+      break;
+    case 'p':
+      this->output_prefix = optarg;
+      break;
+    case 'v':
+      this->params.verbose = true;
+      break;
+
+    case '?':
+      std::exit(EXIT_FAILURE);
+    default:
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  // Sanity checks.
+  if(optind >= argc) { printUsage(EXIT_FAILURE); }
+  this->input = argv[optind]; optind++;
+}
+
+//------------------------------------------------------------------------------

--- a/src/chunk_gbz.cpp
+++ b/src/chunk_gbz.cpp
@@ -38,16 +38,16 @@ main(int argc, char** argv)
   }
   sdsl::simple_sds::load_from(gbz, config.input);
 
-  std::vector<std::pair<std::string, GBZ>> chunks = chunk_graph(gbz, config.params);
+  auto chunks = chunk_graph(gbz, config.params);
 
   if(config.params.verbose)
   {
     std::cerr << "Writing the output files" << std::endl;
   }
-  for(size_t i = 0; i < chunks.size(); i++)
+  for(size_t i = 0; i < chunks.first.size(); i++)
   {
-    std::string filename = config.output_prefix + "_" + std::to_string(i) + "_" + chunks[i].first + ".gbz";
-    sdsl::simple_sds::serialize_to(chunks[i].second, filename);
+    std::string filename = config.output_prefix + "_" + std::to_string(i) + "_" + chunks.second[i] + ".gbz";
+    sdsl::simple_sds::serialize_to(chunks.first[i], filename);
   }
 
   if(config.params.verbose)

--- a/src/gbwtgraph.cpp
+++ b/src/gbwtgraph.cpp
@@ -398,9 +398,28 @@ GBWTGraph::GBWTGraph
 }
 
 GBWTGraph
-GBWTGraph::subgraph(const gbwt::GBWT& gbwt_index) const
+GBWTGraph::subgraph(gbwt::GBWT& gbwt_index) const
 {
   GBWTGraph result;
+
+  // Copy reference samples.
+  if(this->index != nullptr)
+  {
+    auto reference_samples = parse_reference_samples_tag(*this->index);
+    auto present_samples = present_sample_names(reference_samples, gbwt_index);
+    if(!present_samples.empty())
+    {
+      gbwt_index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, compose_reference_samples_tag(present_samples));
+    }
+    else
+    {
+      gbwt_index.tags.unset(REFERENCE_SAMPLE_LIST_GBWT_TAG);
+    }
+  }
+  else
+  {
+    gbwt_index.tags.unset(REFERENCE_SAMPLE_LIST_GBWT_TAG);
+  }
 
   // Set GBWT, cache named paths, and do sanity checks.
   result.set_gbwt(gbwt_index);

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -65,9 +65,9 @@ GBZ::Header::operator==(const Header& another) const
 //------------------------------------------------------------------------------
 
 size_t
-GBZ::set_reference_samples(const std::unordered_set<std::string>& samples)
+GBZ::set_reference_samples(const sample_name_set& samples)
 {
-  std::unordered_set<std::string> present_samples = present_sample_names(samples, this->index);
+  sample_name_set present_samples = present_sample_names(samples, this->index);
 
   std::string tag_value = compose_reference_samples_tag(present_samples);
   this->index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, tag_value);
@@ -209,7 +209,7 @@ GBZ::GBZ(std::vector<GBZ>&& subgraphs)
   }
 
   // Determine the reference samples as a union over the subgraphs.
-  std::unordered_set<std::string> reference_samples;
+  sample_name_set reference_samples;
   for(const gbwt::GBWT& index : indexes)
   {
     auto current_ref_samples = parse_reference_samples_tag(index);

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -188,6 +188,49 @@ GBZ::GBZ(const gbwt::GBWT& index, const NaiveGraph& graph) :
   this->compute_pggname(&parent);
 }
 
+GBZ::GBZ(std::vector<GBZ>&& subgraphs)
+{
+  // Move the GBWTs into a vector for the GBWT merge constructor.
+  std::vector<gbwt::GBWT> indexes;
+  indexes.reserve(subgraphs.size());
+  for(GBZ& subgraph : subgraphs)
+  {
+    indexes.push_back(std::move(subgraph.index));
+    subgraph.graph.set_gbwt_address(indexes.back());
+  }
+
+  // Determine the reference samples as a union over the subgraphs.
+  std::unordered_set<std::string> reference_samples;
+  for(const gbwt::GBWT& index : indexes)
+  {
+    auto current_ref_samples = parse_reference_samples_tag(index);
+    reference_samples.insert(current_ref_samples.begin(), current_ref_samples.end());
+  }
+  std::string reference_samples_tag = compose_reference_samples_tag(reference_samples);
+
+  // Merge the GBWTs and set reference samples.
+  // This may fail if the subgraphs are not disjoint.
+  this->index = gbwt::GBWT(indexes);
+  this->index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, reference_samples_tag);
+
+  // Create the union of the graphs.
+  NaiveGraph sequence_source;
+  for(const GBZ& subgraph : subgraphs)
+  {
+    subgraph.graph.for_each_handle([&](const handle_t& handle)
+    {
+      std::string_view sequence = subgraph.graph.get_sequence_view(handle);
+      sequence_source.create_node(subgraph.graph.get_id(handle), sequence);
+    });
+  }
+  indexes.clear(); subgraphs.clear(); // Free memory before building the GBWTGraph.
+  this->graph = GBWTGraph(this->index, sequence_source);
+
+  // Determine GBZ tags.
+  this->add_source();
+  this->compute_pggname(nullptr);
+}
+
 GBZ::GBZ(gbwt::GBWT&& index, const GBZ& supergraph) :
   index(std::move(index)), graph(supergraph.graph.subgraph(this->index))
 {

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -85,6 +85,7 @@ GBZ::GBZ()
 {
   this->add_source();
   this->set_gbwt();
+  this->compute_pggname(nullptr);
 }
 
 GBZ::GBZ(const GBZ& source)
@@ -190,6 +191,14 @@ GBZ::GBZ(const gbwt::GBWT& index, const NaiveGraph& graph) :
 
 GBZ::GBZ(std::vector<GBZ>&& subgraphs)
 {
+  if(subgraphs.empty())
+  {
+    this->add_source();
+    this->set_gbwt();
+    this->compute_pggname(nullptr);
+    return;
+  }
+
   // Move the GBWTs into a vector for the GBWT merge constructor.
   std::vector<gbwt::GBWT> indexes;
   indexes.reserve(subgraphs.size());
@@ -206,12 +215,15 @@ GBZ::GBZ(std::vector<GBZ>&& subgraphs)
     auto current_ref_samples = parse_reference_samples_tag(index);
     reference_samples.insert(current_ref_samples.begin(), current_ref_samples.end());
   }
-  std::string reference_samples_tag = compose_reference_samples_tag(reference_samples);
 
   // Merge the GBWTs and set reference samples.
   // This may fail if the subgraphs are not disjoint.
   this->index = gbwt::GBWT(indexes);
-  this->index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, reference_samples_tag);
+  if(!reference_samples.empty())
+  {
+    std::string reference_samples_tag = compose_reference_samples_tag(reference_samples);
+    this->index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, reference_samples_tag);
+  }
 
   // Create the union of the graphs.
   NaiveGraph sequence_source;

--- a/src/gbz.cpp
+++ b/src/gbz.cpp
@@ -67,15 +67,7 @@ GBZ::Header::operator==(const Header& another) const
 size_t
 GBZ::set_reference_samples(const std::unordered_set<std::string>& samples)
 {
-  const gbwt::Metadata& metadata = this->index.metadata;
-  std::unordered_set<std::string> present_samples;
-  for(const std::string& sample : samples)
-  {
-    if(metadata.sample(sample) < metadata.samples())
-    {
-      present_samples.insert(sample);
-    }
-  }
+  std::unordered_set<std::string> present_samples = present_sample_names(samples, this->index);
 
   std::string tag_value = compose_reference_samples_tag(present_samples);
   this->index.tags.set(REFERENCE_SAMPLE_LIST_GBWT_TAG, tag_value);
@@ -202,7 +194,6 @@ GBZ::GBZ(gbwt::GBWT&& index, const GBZ& supergraph) :
   this->add_source();
   GraphName parent = supergraph.graph_name();
   this->compute_pggname(&parent, ParentGraphType::SUPERGRAPH);
-
 }
 
 GBZ::GBZ(gbwt::GBWT&& index, const HandleGraph& graph, const NamedNodeBackTranslation* segment_space) :

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -1178,8 +1178,11 @@ parse_header_tags(const GFAFile& gfa_file, const GFAParsingParameters& parameter
         throw std::runtime_error("Expected GFA header tag " + name +
                                  " to have type Z, not type " + std::string(1, type));
       }
-      // Grab the string tag value. It's already in the right format to be a GBWT tag value.
-      result[REFERENCE_SAMPLE_LIST_GBWT_TAG] = std::string(value);
+
+      // Convert value to set to value to get the canonical order for the reference samples.
+      auto ref_samples = parse_reference_samples_tag(value);
+      std::string canonical_value = compose_reference_samples_tag(ref_samples);
+      result[REFERENCE_SAMPLE_LIST_GBWT_TAG] = canonical_value;
     }
   });
   
@@ -1491,7 +1494,8 @@ GFAExtractionParameters::get_mode(const std::string& name)
 struct SegmentCache
 {
   SegmentCache(const GBWTGraph& graph, bool use_translation) :
-    graph(graph), segments((graph.index->sigma() - graph.index->firstNode()) / 2)
+    graph(graph),
+    segments((graph.index->sigma() > graph.index->firstNode() ? (graph.index->sigma() - graph.index->firstNode()) / 2 : 0))
   {
     if(use_translation)
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1358,6 +1358,18 @@ MetadataBuilder::add_walk(const std::string& sample, const std::string& haplotyp
 }
 
 void
+MetadataBuilder::add_gbwt_path(const gbwt::FullPathName& path_name, size_t job)
+{
+  // This also works with generic paths.
+  this->add_path
+  (
+    PathSense::HAPLOTYPE,
+    path_name.sample_name, path_name.contig_name, path_name.haplotype, path_name.offset,
+    PathMetadata::NO_SUBRANGE, job
+  );
+}
+
+void
 MetadataBuilder::add_haplotype(const std::string& sample, const std::string& contig, size_t haplotype, size_t fragment, size_t job)
 {
   this->add_path(PathSense::HAPLOTYPE, sample, contig, haplotype, fragment, PathMetadata::NO_SUBRANGE, job);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,6 +112,20 @@ parse_reference_samples_tag(const gbwt::GBWT& index)
   return parse_reference_samples_tag(index.tags.get(REFERENCE_SAMPLE_LIST_GBWT_TAG));
 }
 
+std::unordered_set<std::string>
+present_sample_names(const std::unordered_set<std::string>& sample_names, const gbwt::GBWT& index)
+{
+  std::unordered_set<std::string> result;
+  for(const auto& sample_name : sample_names)
+  {
+    if(index.metadata.sample(sample_name) < index.metadata.samples())
+    {
+      result.insert(sample_name);
+    }
+  }
+  return result;
+}
+
 std::string
 compose_reference_samples_tag(const std::unordered_set<std::string>& reference_samples)
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -88,17 +88,17 @@ split_view(std::string_view str_view, char separator)
 
 //------------------------------------------------------------------------------
 
-std::unordered_set<std::string>
+sample_name_set
 parse_reference_samples_tag(const char* cursor, const char* end)
 {
   return parse_reference_samples_tag(std::string_view(cursor, end - cursor));
 }
 
-std::unordered_set<std::string>
+sample_name_set
 parse_reference_samples_tag(std::string_view tag_value)
 {
   std::vector<std::string_view> sample_names = split_view(tag_value, REFERENCE_SAMPLE_LIST_SEPARATOR);
-  std::unordered_set<std::string> reference_samples;
+  sample_name_set reference_samples;
   for(const auto& sample_view : sample_names)
   {
     reference_samples.emplace(sample_view.data(), sample_view.size());
@@ -106,16 +106,16 @@ parse_reference_samples_tag(std::string_view tag_value)
   return reference_samples;
 }
 
-std::unordered_set<std::string>
+sample_name_set
 parse_reference_samples_tag(const gbwt::GBWT& index)
 {
   return parse_reference_samples_tag(index.tags.get(REFERENCE_SAMPLE_LIST_GBWT_TAG));
 }
 
-std::unordered_set<std::string>
-present_sample_names(const std::unordered_set<std::string>& sample_names, const gbwt::GBWT& index)
+sample_name_set
+present_sample_names(const sample_name_set& sample_names, const gbwt::GBWT& index)
 {
-  std::unordered_set<std::string> result;
+  sample_name_set result;
   for(const auto& sample_name : sample_names)
   {
     if(index.metadata.sample(sample_name) < index.metadata.samples())
@@ -127,7 +127,7 @@ present_sample_names(const std::unordered_set<std::string>& sample_names, const 
 }
 
 std::string
-compose_reference_samples_tag(const std::unordered_set<std::string>& reference_samples)
+compose_reference_samples_tag(const sample_name_set& reference_samples)
 {
   // We sort the sample names to make the output deterministic across
   // standard library implementations.
@@ -154,13 +154,13 @@ compose_reference_samples_tag(const std::unordered_set<std::string>& reference_s
 }
 
 PathSense
-get_path_sense(const gbwt::Metadata& metadata, const gbwt::PathName& path_name, const std::unordered_set<std::string>& reference_samples)
+get_path_sense(const gbwt::Metadata& metadata, const gbwt::PathName& path_name, const sample_name_set& reference_samples)
 {
   return get_sample_sense(metadata, path_name.sample, reference_samples);
 }
 
 PathSense
-get_path_sense(const gbwt::GBWT& index, gbwt::size_type path_number, const std::unordered_set<std::string>& reference_samples)
+get_path_sense(const gbwt::GBWT& index, gbwt::size_type path_number, const sample_name_set& reference_samples)
 {
   if(!index.hasMetadata() || !index.metadata.hasPathNames() || path_number >= index.metadata.paths())
   {
@@ -170,7 +170,7 @@ get_path_sense(const gbwt::GBWT& index, gbwt::size_type path_number, const std::
 }
 
 PathSense
-get_sample_sense(const gbwt::Metadata& metadata, gbwt::size_type sample, const std::unordered_set<std::string>& reference_samples)
+get_sample_sense(const gbwt::Metadata& metadata, gbwt::size_type sample, const sample_name_set& reference_samples)
 {
   if(!metadata.hasSampleNames() || sample >= metadata.sample_names.size())
   {
@@ -181,7 +181,7 @@ get_sample_sense(const gbwt::Metadata& metadata, gbwt::size_type sample, const s
 }
 
 PathSense
-get_sample_sense(const std::string& sample_name, const std::unordered_set<std::string>& reference_samples)
+get_sample_sense(const std::string& sample_name, const sample_name_set& reference_samples)
 {
   if(sample_name == GENERIC_PATH_SAMPLE_NAME)
   {
@@ -341,7 +341,7 @@ void
 set_sample_path_senses(gbwt::Tags& tags, const std::unordered_map<std::string, PathSense>& senses)
 {
   // Find all the current reference samples
-  std::unordered_set<std::string> reference_sample_names = parse_reference_samples_tag(tags.get(REFERENCE_SAMPLE_LIST_GBWT_TAG));
+  sample_name_set reference_sample_names = parse_reference_samples_tag(tags.get(REFERENCE_SAMPLE_LIST_GBWT_TAG));
 
   for(auto& kv : senses)
   {

--- a/tests/gfas/for_subgraph.gfa
+++ b/tests/gfas/for_subgraph.gfa
@@ -1,4 +1,4 @@
-H	VN:Z:1.1
+H	VN:Z:1.1	RS:Z:odd
 H	NM:Z:a148a3d153848874143026b80854aea55825ae27ef81a774d1d4afd0ad0166f9
 # Segments contain sequences that can be chopped.
 # If we skip odd walks, we do not use the first and the last segment.

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -30,8 +30,20 @@ using gbwtgraph::pos_t;
 //------------------------------------------------------------------------------
 
 // GBWT / GBWTGraph / GBZ comparisons.
-// TODO: These could be member functions of GBWT / GBWTGraph / GBZ that return an error message on failure.
 
+// Do not call directly in tests.
+void compare_tags(const gbwt::Tags& tags, const gbwt::Tags& truth, const std::string& test_case)
+{
+  EXPECT_EQ(tags.size(), truth.size()) << "Wrong number of tags" << test_case;
+  size_t min_size = std::min(tags.size(), truth.size());
+  size_t i = 0;
+  for(auto first = tags.tags.begin(), second = truth.tags.begin(); i < min_size; ++first, ++second, i++)
+  {
+    EXPECT_EQ(*first, *second) << "Wrong tag at index " << i << test_case;
+  }
+}
+
+// TODO: We have a similar comparison function in GBWT tests.
 void compare_gbwts(const gbwt::GBWT& index, const gbwt::GBWT& truth, bool check_metadata, const std::string& test_case_name)
 {
   std::string test_case = (test_case_name.empty() ? std::string() : std::string(" in ") + test_case_name);
@@ -45,10 +57,22 @@ void compare_gbwts(const gbwt::GBWT& index, const gbwt::GBWT& truth, bool check_
       truth_header.unset(gbwt::GBWTHeader::FLAG_METADATA);
     }
     bool same_header = (index_header == truth_header);
+    if(!same_header)
+    {
+      EXPECT_EQ(index_header.sequences, truth_header.sequences) << "Wrong number of sequences in GBWT header" << test_case;
+      EXPECT_EQ(index_header.size, truth_header.size) << "Wrong size in GBWT header" << test_case;
+      EXPECT_EQ(index_header.offset, truth_header.offset) << "Wrong offset in GBWT header" << test_case;
+      EXPECT_EQ(index_header.alphabet_size, truth_header.alphabet_size) << "Wrong alphabet size in GBWT header" << test_case;
+      EXPECT_EQ(index_header.flags, truth_header.flags) << "Wrong flags in GBWT header" << test_case;
+    }
     ASSERT_TRUE(same_header) << "Wrong GBWT header" << test_case;
   }
 
   bool same_tags = (index.tags == truth.tags);
+  if(!same_tags)
+  {
+    compare_tags(index.tags, truth.tags, test_case);
+  }
   ASSERT_TRUE(same_tags) << "Wrong GBWT tags" << test_case;
 
   bool same_recordarray_index = (index.bwt.index == truth.bwt.index);
@@ -57,6 +81,15 @@ void compare_gbwts(const gbwt::GBWT& index, const gbwt::GBWT& truth, bool check_
   ASSERT_TRUE(same_recordarray_data) << "Wrong data for GBWT records" << test_case;
 
   bool same_dasamples_sampled = (index.da_samples.sampled_records == truth.da_samples.sampled_records);
+  if(!same_dasamples_sampled)
+  {
+    EXPECT_EQ(index.da_samples.sampled_records.size(), truth.da_samples.sampled_records.size()) << "Wrong number of records in DA samples" << test_case;
+    size_t min_size = std::min(index.da_samples.sampled_records.size(), truth.da_samples.sampled_records.size());
+    for(size_t i = 0; i < min_size; i++)
+    {
+      EXPECT_EQ(index.da_samples.sampled_records[i], truth.da_samples.sampled_records[i]) << "Wrong sampled status for record " << i << " in DA samples" << test_case;
+    }
+  }
   ASSERT_TRUE(same_dasamples_sampled) << "Wrong sampled records in DA samples" << test_case;
   bool same_dasamples_ranges = (index.da_samples.bwt_ranges == truth.da_samples.bwt_ranges);
   ASSERT_TRUE(same_dasamples_ranges) << "Wrong BWT ranges in DA samples" << test_case;
@@ -109,8 +142,13 @@ void compare_gbzs(const gbwtgraph::GBZ& gbz, const gbwtgraph::GBZ& truth, bool c
 
   bool same_header = (gbz.header == truth.header);
   ASSERT_TRUE(same_header) << "Wrong GBZ header" << test_case;
+
   bool same_tags = (gbz.tags == truth.tags);
-  ASSERT_TRUE(same_tags) << "Wrong GBZ tags" << test_case;
+  if(!same_tags)
+  {
+    compare_tags(gbz.tags, truth.tags, test_case);
+  }
+//  ASSERT_TRUE(same_tags) << "Wrong GBZ tags" << test_case;
 
   compare_gbwts(gbz.index, truth.index, check_metadata, test_case_name);
   compare_graphs(gbz.graph, truth.graph, check_translation, test_case_name);

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -8,8 +8,8 @@
 
 #include <gbwt/dynamic_gbwt.h>
 
+#include <gbwtgraph/gbz.h>
 #include <gbwtgraph/minimizer.h>
-#include <gbwtgraph/gbwtgraph.h>
 #include <gbwtgraph/naive_graph.h>
 
 #include <gtest/gtest.h>
@@ -26,6 +26,94 @@ namespace
 using gbwtgraph::nid_t;
 using gbwtgraph::handle_t;
 using gbwtgraph::pos_t;
+
+//------------------------------------------------------------------------------
+
+// GBWT / GBWTGraph / GBZ comparisons.
+
+void compare_gbwts(const gbwt::GBWT& index, const gbwt::GBWT& truth, bool check_metadata, const std::string& test_case_name)
+{
+  std::string test_case = (test_case_name.empty() ? std::string() : std::string(" in ") + test_case_name);
+
+  {
+    gbwt::GBWTHeader index_header = index.header;
+    gbwt::GBWTHeader truth_header = truth.header;
+    if(!check_metadata)
+    {
+      index_header.unset(gbwt::GBWTHeader::FLAG_METADATA);
+      truth_header.unset(gbwt::GBWTHeader::FLAG_METADATA);
+    }
+    bool same_header = (index_header == truth_header);
+    ASSERT_TRUE(same_header) << "Wrong GBWT header" << test_case;
+  }
+
+  bool same_tags = (index.tags == truth.tags);
+  ASSERT_TRUE(same_tags) << "Wrong GBWT tags" << test_case;
+
+  bool same_recordarray_index = (index.bwt.index == truth.bwt.index);
+  ASSERT_TRUE(same_recordarray_index) << "Wrong index for GBWT records" << test_case;
+  bool same_recordarray_data = (index.bwt.data == truth.bwt.data);
+  ASSERT_TRUE(same_recordarray_data) << "Wrong data for GBWT records" << test_case;
+
+  bool same_dasamples_sampled = (index.da_samples.sampled_records == truth.da_samples.sampled_records);
+  ASSERT_TRUE(same_dasamples_sampled) << "Wrong sampled records in DA samples" << test_case;
+  bool same_dasamples_ranges = (index.da_samples.bwt_ranges == truth.da_samples.bwt_ranges);
+  ASSERT_TRUE(same_dasamples_ranges) << "Wrong BWT ranges in DA samples" << test_case;
+  bool same_dasamples_offsets = (index.da_samples.sampled_offsets == truth.da_samples.sampled_offsets);
+  ASSERT_TRUE(same_dasamples_offsets) << "Wrong sampled offsets in DA samples" << test_case;
+  bool same_dasamples_samples = (index.da_samples.array == truth.da_samples.array);
+  ASSERT_TRUE(same_dasamples_samples) << "Wrong samples in DA samples" << test_case;
+
+  if(check_metadata)
+  {
+    bool same_metadata = (index.metadata == truth.metadata);
+    ASSERT_TRUE(same_metadata) << "Wrong GBWT metadata" << test_case;
+  }
+}
+
+void compare_graphs(const gbwtgraph::GBWTGraph& graph, const gbwtgraph::GBWTGraph& truth, bool check_translation, const std::string& test_case_name)
+{
+  std::string test_case = (test_case_name.empty() ? std::string() : std::string(" in ") + test_case_name);
+
+  {
+    gbwtgraph::GBWTGraph::Header graph_header = graph.header;
+    gbwtgraph::GBWTGraph::Header truth_header = truth.header;
+    if(!check_translation)
+    {
+      graph_header.unset(gbwtgraph::GBWTGraph::Header::FLAG_TRANSLATION);
+      truth_header.unset(gbwtgraph::GBWTGraph::Header::FLAG_TRANSLATION);
+    }
+    bool same_header = (graph_header == truth_header);
+    ASSERT_TRUE(same_header) << "Wrong GBWTGraph header" << test_case;
+  }
+
+  bool same_sequences = (graph.sequences == truth.sequences);
+  ASSERT_TRUE(same_sequences) << "Wrong sequences in GBWTGraph" << test_case;
+
+  bool same_real_nodes = (graph.real_nodes == truth.real_nodes);
+  ASSERT_TRUE(same_real_nodes) << "Wrong real nodes in GBWTGraph" << test_case;
+
+  if(check_translation)
+  {
+    bool same_segments = (graph.segments == truth.segments);
+    ASSERT_TRUE(same_segments) << "Wrong segment names in GBWTGraph" << test_case;
+    bool same_translation = (graph.node_to_segment == truth.node_to_segment);
+    ASSERT_TRUE(same_translation) << "Wrong node-to-segment translation in GBWTGraph" << test_case;
+  }
+}
+
+void compare_gbzs(const gbwtgraph::GBZ& gbz, const gbwtgraph::GBZ& truth, bool check_metadata, bool check_translation, const std::string& test_case_name)
+{
+  std::string test_case = (test_case_name.empty() ? std::string() : std::string(" in ") + test_case_name);
+
+  bool same_header = (gbz.header == truth.header);
+  ASSERT_TRUE(same_header) << "Wrong GBZ header" << test_case;
+  bool same_tags = (gbz.tags == truth.tags);
+  ASSERT_TRUE(same_tags) << "Wrong GBZ tags" << test_case;
+
+  compare_gbwts(gbz.index, truth.index, check_metadata, test_case_name);
+  compare_graphs(gbz.graph, truth.graph, check_translation, test_case_name);
+}
 
 //------------------------------------------------------------------------------
 

--- a/tests/shared.h
+++ b/tests/shared.h
@@ -30,6 +30,7 @@ using gbwtgraph::pos_t;
 //------------------------------------------------------------------------------
 
 // GBWT / GBWTGraph / GBZ comparisons.
+// TODO: These could be member functions of GBWT / GBWTGraph / GBZ that return an error message on failure.
 
 void compare_gbwts(const gbwt::GBWT& index, const gbwt::GBWT& truth, bool check_metadata, const std::string& test_case_name)
 {

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -509,30 +509,6 @@ TEST_F(ChunkMergeTest, TwoComponents)
   compare_gbzs(merged, graph, true, true, "");
 }
 
-TEST_F(ChunkMergeTest, MultiThreaded)
-{
-  GFAParsingParameters gfa_params = this->get_params();
-  auto gfa_parse = gfa_to_gbwt("gfas/components_ref.gfa", gfa_params);
-  GBZ graph(gfa_parse.first, gfa_parse.second);
-
-  ChunkParameters params;
-  auto single_threaded = chunk_graph(graph, params);
-  params.parallel_jobs = 2;
-  auto multi_threaded = chunk_graph(graph, params);
-
-  ASSERT_EQ(single_threaded.first.size(), multi_threaded.first.size()) << "Wrong number of chunks in multi-threaded chunking";
-  for(size_t i = 0; i < single_threaded.first.size(); i++)
-  {
-    compare_gbzs(single_threaded.first[i], multi_threaded.first[i], true, true, "chunk " + std::to_string(i));
-  }
-
-  ASSERT_EQ(single_threaded.second.size(), multi_threaded.second.size()) << "Wrong number of contig names in multi-threaded chunking";
-  for(size_t i = 0; i < single_threaded.second.size(); i++)
-  {
-    EXPECT_EQ(single_threaded.second[i], multi_threaded.second[i]) << "Incorrect contig name for chunk " << i << " in multi-threaded chunking";
-  }
-}
-
 TEST_F(ChunkMergeTest, WithTranslation)
 {
   GFAParsingParameters gfa_params = this->get_params();

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -486,12 +486,17 @@ TEST_F(ChunkMergeTest, TwoComponents)
   ChunkParameters params;
   auto chunks = chunk_graph(graph, params);
   ASSERT_EQ(chunks.first.size(), size_t(2)) << "Wrong number of chunks for a two-component graph";
+  size_t total_nodes = 0;
   for(size_t i = 0; i < chunks.first.size(); i++)
   {
     GraphName chunk = chunks.first[i].graph_name();
     bool is_subgraph = chunk.subgraph_of(parent);
     EXPECT_TRUE(is_subgraph) << "Chunk " << i << " is not a subgraph of the original graph";
+    size_t node_count = chunks.first[i].graph.get_node_count();
+    EXPECT_GT(node_count, size_t(0)) << "Chunk " << i << " is empty";
+    total_nodes += node_count;
   }
+  EXPECT_EQ(total_nodes, graph.graph.get_node_count()) << "Total number of nodes in chunks does not match original graph";
 
   std::vector<std::string> expected_names { "A", "B" };
   ASSERT_EQ(chunks.second.size(), expected_names.size()) << "Wrong number of contig names for a two-component graph";
@@ -526,6 +531,29 @@ TEST_F(ChunkMergeTest, MultiThreaded)
   {
     EXPECT_EQ(single_threaded.second[i], multi_threaded.second[i]) << "Incorrect contig name for chunk " << i << " in multi-threaded chunking";
   }
+}
+
+TEST_F(ChunkMergeTest, WithTranslation)
+{
+  GFAParsingParameters gfa_params = this->get_params();
+  gfa_params.max_node_length = 3;
+  auto gfa_parse = gfa_to_gbwt("gfas/example_chopping.gfa", gfa_params);
+  GBZ graph(gfa_parse.first, gfa_parse.second);
+  ASSERT_TRUE(graph.graph.has_segment_names()) << "Original graph should have node-to-segment translation";
+
+  // Our original graph has a node-to-segment translation.
+  // The corresponding GraphName tags do not survive the round-trip.
+  graph.tags.unset(GraphName::GBZ_TRANSLATION_TAG);
+  graph.tags.unset(GraphName::GBZ_TRANSLATION_TARGET_TAG);
+
+  ChunkParameters params;
+  auto chunks = chunk_graph(graph, params);
+  ASSERT_EQ(chunks.first.size(), size_t(1)) << "Wrong number of chunks for a single-component graph";
+  ASSERT_FALSE(chunks.first[0].graph.has_segment_names()) << "Chunk should not have node-to-segment translation";
+
+  GBZ merged(std::move(chunks.first));
+  compare_gbzs(merged, graph, true, false, "");
+  ASSERT_FALSE(merged.graph.has_segment_names()) << "Merged graph should not have node-to-segment translation";
 }
 
 TEST_F(ChunkMergeTest, ByContigName)

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -443,6 +443,8 @@ TEST_F(TopologicalOrderTest, MissingNodes)
 // multi-component -> chunk -> merge -> compare
 // multi-component: chunk all vs. chunk by contig name
 
+// also check pggnames: that the chunks are subgraphs of the original graph
+
 //------------------------------------------------------------------------------
 
 class LCSTest : public ::testing::Test

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -436,14 +436,119 @@ TEST_F(TopologicalOrderTest, MissingNodes)
 
 //------------------------------------------------------------------------------
 
-// FIXME: chunk_graph
+class ChunkMergeTest : public ::testing::Test
+{
+public:
+  // Some test graphs have reference paths as P-lines with PanSN names.
+  GFAParsingParameters get_params() const
+  {
+    GFAParsingParameters params;
+    params.path_name_formats.clear();
+    params.path_name_formats.emplace_back(GFAParsingParameters::PAN_SN_REGEX, GFAParsingParameters::PAN_SN_FIELDS, GFAParsingParameters::PAN_SN_SENSE);
+    params.path_name_formats.emplace_back(GFAParsingParameters::DEFAULT_REGEX, GFAParsingParameters::DEFAULT_FIELDS, GFAParsingParameters::DEFAULT_SENSE);
+    return params;
+  }
+};
 
-// empty -> chunk -> merge -> compare
-// single-component -> chunk -> merge -> compare
-// multi-component -> chunk -> merge -> compare
-// multi-component: chunk all vs. chunk by contig name
+TEST_F(ChunkMergeTest, Empty)
+{
+  GBZ empty;
 
-// also check pggnames: that the chunks are subgraphs of the original graph
+  ChunkParameters params;
+  auto chunks = chunk_graph(empty, params);
+  ASSERT_TRUE(chunks.first.empty()) << "Non-empty chunking of an empty graph";
+
+  GBZ merged(std::move(chunks.first));
+  compare_gbzs(empty, merged, true, true, "");
+}
+
+TEST_F(ChunkMergeTest, SingleComponent)
+{
+  GFAParsingParameters gfa_params = this->get_params();
+  auto gfa_parse = gfa_to_gbwt("gfas/example_reference.gfa", gfa_params);
+  GBZ graph(gfa_parse.first, gfa_parse.second);
+
+  ChunkParameters params;
+  auto chunks = chunk_graph(graph, params);
+  ASSERT_EQ(chunks.first.size(), size_t(1)) << "Wrong number of chunks for a single-component graph";
+
+  GBZ merged(std::move(chunks.first));
+  compare_gbzs(merged, graph, true, true, "");
+}
+
+TEST_F(ChunkMergeTest, TwoComponents)
+{
+  GFAParsingParameters gfa_params = this->get_params();
+  auto gfa_parse = gfa_to_gbwt("gfas/components_ref.gfa", gfa_params);
+  GBZ graph(gfa_parse.first, gfa_parse.second);
+  GraphName parent = graph.graph_name();
+
+  ChunkParameters params;
+  auto chunks = chunk_graph(graph, params);
+  ASSERT_EQ(chunks.first.size(), size_t(2)) << "Wrong number of chunks for a two-component graph";
+  for(size_t i = 0; i < chunks.first.size(); i++)
+  {
+    GraphName chunk = chunks.first[i].graph_name();
+    bool is_subgraph = chunk.subgraph_of(parent);
+    EXPECT_TRUE(is_subgraph) << "Chunk " << i << " is not a subgraph of the original graph";
+  }
+
+  std::vector<std::string> expected_names { "A", "B" };
+  ASSERT_EQ(chunks.second.size(), expected_names.size()) << "Wrong number of contig names for a two-component graph";
+  for(size_t i = 0; i < expected_names.size(); i++)
+  {
+    EXPECT_EQ(chunks.second[i], expected_names[i]) << "Incorrect contig name for chunk " << i;
+  }
+
+  GBZ merged(std::move(chunks.first));
+  compare_gbzs(merged, graph, true, true, "");
+}
+
+TEST_F(ChunkMergeTest, MultiThreaded)
+{
+  GFAParsingParameters gfa_params = this->get_params();
+  auto gfa_parse = gfa_to_gbwt("gfas/components_ref.gfa", gfa_params);
+  GBZ graph(gfa_parse.first, gfa_parse.second);
+
+  ChunkParameters params;
+  auto single_threaded = chunk_graph(graph, params);
+  params.parallel_jobs = 2;
+  auto multi_threaded = chunk_graph(graph, params);
+
+  ASSERT_EQ(single_threaded.first.size(), multi_threaded.first.size()) << "Wrong number of chunks in multi-threaded chunking";
+  for(size_t i = 0; i < single_threaded.first.size(); i++)
+  {
+    compare_gbzs(single_threaded.first[i], multi_threaded.first[i], true, true, "chunk " + std::to_string(i));
+  }
+
+  ASSERT_EQ(single_threaded.second.size(), multi_threaded.second.size()) << "Wrong number of contig names in multi-threaded chunking";
+  for(size_t i = 0; i < single_threaded.second.size(); i++)
+  {
+    EXPECT_EQ(single_threaded.second[i], multi_threaded.second[i]) << "Incorrect contig name for chunk " << i << " in multi-threaded chunking";
+  }
+}
+
+TEST_F(ChunkMergeTest, ByContigName)
+{
+  GFAParsingParameters gfa_params = this->get_params();
+  auto gfa_parse = gfa_to_gbwt("gfas/components_ref.gfa", gfa_params);
+  GBZ graph(gfa_parse.first, gfa_parse.second);
+
+  ChunkParameters params;
+  auto chunks = chunk_graph(graph, params);
+
+  for(size_t i = 0; i < chunks.first.size(); i++)
+  {
+    params.contig_name = chunks.second[i];
+    auto new_chunks = chunk_graph(graph, params);
+    ASSERT_EQ(new_chunks.first.size(), size_t(1)) << "Wrong number of chunks for contig name " << params.contig_name;
+    compare_gbzs(new_chunks.first[0], chunks.first[i], true, true, "chunk " + std::to_string(i) + " with contig name " + params.contig_name);
+  }
+
+  params.contig_name = "nonexistent_contig";
+  auto new_chunks = chunk_graph(graph, params);
+  ASSERT_TRUE(new_chunks.first.empty()) << "Found a chunk for a non-existent contig name";
+}
 
 //------------------------------------------------------------------------------
 

--- a/tests/test_algorithms.cpp
+++ b/tests/test_algorithms.cpp
@@ -436,6 +436,15 @@ TEST_F(TopologicalOrderTest, MissingNodes)
 
 //------------------------------------------------------------------------------
 
+// FIXME: chunk_graph
+
+// empty -> chunk -> merge -> compare
+// single-component -> chunk -> merge -> compare
+// multi-component -> chunk -> merge -> compare
+// multi-component: chunk all vs. chunk by contig name
+
+//------------------------------------------------------------------------------
+
 class LCSTest : public ::testing::Test
 {
 public:

--- a/tests/test_gbwtgraph.cpp
+++ b/tests/test_gbwtgraph.cpp
@@ -589,15 +589,6 @@ public:
     this->source = build_naive_graph(false);
     this->graph = GBWTGraph(this->index, this->source);
   }
-
-  void check_graph(const GBWTGraph& graph, const GBWTGraph& truth) const
-  {
-    ASSERT_EQ(graph.header, truth.header) << "Serialization did not preserve the header";
-    ASSERT_EQ(graph.sequences, truth.sequences) << "Serialization did not preserve the sequences";
-    ASSERT_EQ(graph.real_nodes, truth.real_nodes) << "Serialization did not preserve the real nodes";
-    ASSERT_EQ(graph.segments, truth.segments) << "Serialization did not preserve the segments";
-    ASSERT_EQ(graph.node_to_segment, truth.node_to_segment) << "Serialization did not preserve the node-to-segment mapping";
-  }
 };
 
 TEST_F(GraphSerialization, SerializeEmpty)
@@ -608,7 +599,7 @@ TEST_F(GraphSerialization, SerializeEmpty)
 
   GBWTGraph duplicate_graph;
   duplicate_graph.deserialize(filename);
-  this->check_graph(duplicate_graph, empty_graph);
+  compare_graphs(duplicate_graph, empty_graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -628,7 +619,7 @@ TEST_F(GraphSerialization, CompressEmpty)
   ASSERT_EQ(bytes, expected_size) << "Invalid file size";
   duplicate_graph.simple_sds_load(in, *(empty_graph.index));
   in.close();
-  this->check_graph(duplicate_graph, empty_graph);
+  compare_graphs(duplicate_graph, empty_graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -641,7 +632,7 @@ TEST_F(GraphSerialization, SerializeNonEmpty)
   GBWTGraph duplicate_graph;
   duplicate_graph.deserialize(filename);
   duplicate_graph.set_gbwt(this->index);
-  this->check_graph(duplicate_graph, this->graph);
+  compare_graphs(duplicate_graph, this->graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -658,7 +649,7 @@ TEST_F(GraphSerialization, CompressNonEmpty)
   ASSERT_EQ(bytes, expected_size) << "Invalid file size";
   duplicate_graph.simple_sds_load(in, this->index);
   in.close();
-  this->check_graph(duplicate_graph, this->graph);
+  compare_graphs(duplicate_graph, this->graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -674,7 +665,7 @@ TEST_F(GraphSerialization, SerializeTranslation)
   GBWTGraph duplicate_graph;
   duplicate_graph.deserialize(filename);
   duplicate_graph.set_gbwt(this->index);
-  this->check_graph(duplicate_graph, graph);
+  compare_graphs(duplicate_graph, graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -693,7 +684,7 @@ TEST_F(GraphSerialization, CompressTranslation)
   ASSERT_EQ(bytes, expected_size) << "Invalid file size";
   duplicate_graph.simple_sds_load(in, this->index);
   in.close();
-  this->check_graph(duplicate_graph, graph);
+  compare_graphs(duplicate_graph, graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }
@@ -713,7 +704,7 @@ TEST_F(GraphSerialization, DecompressSerialized)
   EXPECT_EQ(ntohl(magic), graph.get_magic_number()) << "Magic number missing from serialized graph";
   duplicate_graph.simple_sds_load(in, this->index);
   in.close();
-  this->check_graph(duplicate_graph, graph);
+  compare_graphs(duplicate_graph, graph, true, "");
 
   gbwt::TempFile::remove(filename);
 }

--- a/tests/test_gbz.cpp
+++ b/tests/test_gbz.cpp
@@ -164,17 +164,17 @@ public:
     return GBZ(parse.first, parse.second);
   }
 
-  void set_reference_samples(GBZ& gbz, const std::unordered_set<std::string>& samples, size_t expected, const std::string& test)
+  void set_reference_samples(GBZ& gbz, const sample_name_set& samples, size_t expected, const std::string& test)
   {
     size_t present = gbz.set_reference_samples(samples);
     ASSERT_EQ(present, expected) << test << ": Unexpected number of sample names present in the graph";
   }
 
-  void check_named_paths(const GBZ& gbz, const std::unordered_set<std::string>& true_samples, size_t expected_paths, const std::string& test)
+  void check_named_paths(const GBZ& gbz, const sample_name_set& true_samples, size_t expected_paths, const std::string& test)
   {
     ASSERT_EQ(gbz.named_paths(), expected_paths) << test << ": Invalid number of named paths";
 
-    const std::unordered_set<std::string>& samples = gbz.get_reference_samples();
+    const sample_name_set& samples = gbz.get_reference_samples();
     ASSERT_EQ(samples.size(), true_samples.size()) << test << ": Invalid number of reference samples";
     for(const std::string& sample : true_samples)
     {
@@ -204,8 +204,8 @@ public:
 TEST_F(GBZFunctionality, ReferenceSamples)
 {
   GBZ gbz = this->build_gbz("gfas/components_ref.gfa");
-  std::unordered_set<std::string> samples { "ref" };
-  std::unordered_set<std::string> true_samples = samples;
+  sample_name_set samples { "ref" };
+  sample_name_set true_samples = samples;
   this->check_named_paths(gbz, true_samples, 2, "Initial graph");
 
   samples.erase("ref");

--- a/tests/test_gbz.cpp
+++ b/tests/test_gbz.cpp
@@ -10,6 +10,9 @@ using namespace gbwtgraph;
 namespace
 {
 
+// Subgraph constructor is tested in test_gfa.cpp.
+// Chunking and merging GBZs is tested in test_algorithms.cpp.
+
 //------------------------------------------------------------------------------
 
 class GBZSerialization : public ::testing::Test

--- a/tests/test_gfa.cpp
+++ b/tests/test_gfa.cpp
@@ -515,16 +515,26 @@ public:
   gbwt::GBWT select_paths(const gbwt::GBWT& source, gbwt::size_type skip) const
   {
     gbwt::GBWTBuilder builder(sdsl::bits::length(source.sigma() - 1), source.size());
+    MetadataBuilder metadata_builder;
     for(gbwt::size_type path_id = 0; path_id < source.metadata.paths(); path_id += 1 + skip)
     {
       gbwt::vector_type path = source.extract(gbwt::Path::encode(path_id, false));
       builder.insert(path, true);
+      gbwt::FullPathName path_name = source.metadata.fullPath(path_id);
+      metadata_builder.add_path
+      (
+        PathSense::HAPLOTYPE,
+        path_name.sample_name, path_name.contig_name, path_name.haplotype, path_name.offset,
+        PathMetadata::NO_SUBRANGE
+      );
     }
     builder.finish();
+    builder.index.addMetadata();
+    builder.index.metadata = metadata_builder.get_metadata();
     return builder.index;
   }
 
-  void check_subgraph(const GBWTGraph& graph, const GBWTGraph& subgraph) const
+  void check_subgraph(const GBWTGraph& graph, const GBWTGraph& subgraph, size_t expected_ref_sample_count) const
   {
     bool nodes_ok = true;
     bool sequences_ok = true;
@@ -546,6 +556,12 @@ public:
       if(!(graph.has_edge(edge.first, edge.second))) { edges_ok = false; }
     });
     ASSERT_TRUE(edges_ok) << "Some edges were missing from the supergraph";
+
+    auto parent_ref_samples = parse_reference_samples_tag(*(graph.index));
+    auto expected_ref_samples = present_sample_names(parent_ref_samples, *(subgraph.index));
+    auto found_ref_samples = parse_reference_samples_tag(*(subgraph.index));
+    ASSERT_EQ(found_ref_samples.size(), expected_ref_sample_count) << "Wrong number of reference samples in the subgraph";
+    ASSERT_EQ(found_ref_samples, expected_ref_samples) << "Wrong reference samples in the subgraph";
   }
 };
 
@@ -557,7 +573,7 @@ TEST_F(GBWTSubgraph, WithoutTranslation)
   GBZ subgraph(std::move(selected), gbz);
 
   ASSERT_NO_THROW(subgraph.graph.sanity_checks()) << "The subgraph failed sanity checks";
-  this->check_subgraph(gbz.graph, subgraph.graph);
+  this->check_subgraph(gbz.graph, subgraph.graph, 0);
   EXPECT_FALSE(subgraph.graph.has_segment_names()) << "The subgraph has segment names";
 }
 
@@ -571,7 +587,19 @@ TEST_F(GBWTSubgraph, WithTranslation)
   GBZ subgraph(std::move(selected), gbz);
 
   ASSERT_NO_THROW(subgraph.graph.sanity_checks()) << "The subgraph failed sanity checks";
-  this->check_subgraph(gbz.graph, subgraph.graph);
+  this->check_subgraph(gbz.graph, subgraph.graph, 0);
+  EXPECT_FALSE(subgraph.graph.has_segment_names()) << "The subgraph has segment names";
+}
+
+TEST_F(GBWTSubgraph, AllPaths)
+{
+  auto gfa_parse = gfa_to_gbwt("gfas/for_subgraph.gfa");
+  GBZ gbz(gfa_parse.first, gfa_parse.second);
+  gbwt::GBWT selected = this->select_paths(gbz.index, 0);
+  GBZ subgraph(std::move(selected), gbz);
+
+  ASSERT_NO_THROW(subgraph.graph.sanity_checks()) << "The subgraph failed sanity checks";
+  this->check_subgraph(gbz.graph, subgraph.graph, 1);
   EXPECT_FALSE(subgraph.graph.has_segment_names()) << "The subgraph has segment names";
 }
 

--- a/tests/test_gfa.cpp
+++ b/tests/test_gfa.cpp
@@ -521,12 +521,7 @@ public:
       gbwt::vector_type path = source.extract(gbwt::Path::encode(path_id, false));
       builder.insert(path, true);
       gbwt::FullPathName path_name = source.metadata.fullPath(path_id);
-      metadata_builder.add_path
-      (
-        PathSense::HAPLOTYPE,
-        path_name.sample_name, path_name.contig_name, path_name.haplotype, path_name.offset,
-        PathMetadata::NO_SUBRANGE
-      );
+      metadata_builder.add_gbwt_path(path_name);
     }
     builder.finish();
     builder.index.addMetadata();

--- a/tests/test_gfa.cpp
+++ b/tests/test_gfa.cpp
@@ -17,6 +17,8 @@ namespace
 
 //------------------------------------------------------------------------------
 
+// We do not check GBWT metadata here, as we have separate tests (GBWTMetadata) for that.
+// We also do not check node-to-segment translation in compare_graphs(), as we have a separate check for that.
 class GFAConstruction : public ::testing::Test
 {
 public:
@@ -33,41 +35,6 @@ public:
     this->index = build_gbwt_index();
     this->source = build_naive_graph(false);
     this->graph = GBWTGraph(this->index, this->source);
-  }
-
-  void check_gbwt(const gbwt::GBWT& gfa_index, const gbwt::GBWT* truth) const
-  {
-    ASSERT_EQ(gfa_index.size(), truth->size()) << "Different data size";
-    ASSERT_EQ(gfa_index.sequences(), truth->sequences()) << "Number of sequences";
-    ASSERT_EQ(gfa_index.sigma(), truth->sigma()) << "Different alphabet size";
-    ASSERT_EQ(gfa_index.effective(), truth->effective()) << "Different effective alphabet size";
-    ASSERT_EQ(gfa_index.samples(), truth->samples()) << "Different number of samples";
-  }
-
-  void check_graph(const GBWTGraph& gfa_graph, const GBWTGraph* truth) const
-  {
-    // Only check node counts. Headers may be different due to flags that are out of
-    // scope for this test.
-    ASSERT_EQ(gfa_graph.get_node_count(), truth->get_node_count()) << "Node counts are not identical";
-
-    truth->for_each_handle([&](const handle_t& handle)
-    {
-      nid_t node_id = truth->get_id(handle);
-      ASSERT_TRUE(gfa_graph.has_node(gfa_graph.get_id(handle))) << "GFA graph does not have node " << node_id;
-      EXPECT_EQ(gfa_graph.get_sequence(gfa_graph.get_handle(node_id, false)),
-                truth->get_sequence(truth->get_handle(node_id, false))) << "Wrong forward sequence for node " << node_id;
-      EXPECT_EQ(gfa_graph.get_sequence(gfa_graph.get_handle(node_id, true)),
-                truth->get_sequence(truth->get_handle(node_id, true))) << "Wrong reverse sequence for node " << node_id;
-    });
-
-    truth->for_each_edge([&](const edge_t& edge)
-    {
-      nid_t id_from = truth->get_id(edge.first), id_to = truth->get_id(edge.second);
-      bool rev_from = truth->get_is_reverse(edge.first), rev_to = truth->get_is_reverse(edge.second);
-      handle_t from = gfa_graph.get_handle(id_from, rev_from);
-      handle_t to = gfa_graph.get_handle(id_to, rev_to);
-      EXPECT_TRUE(gfa_graph.has_edge(from, to)) << "GFA graph does not have the edge ((" << id_from << ", " << rev_from <<"), (" << id_to << ", " << rev_to << "))";
-    });
   }
 
   void check_paths(const GBWTGraph& gfa_graph, const GBWTGraph* truth) const
@@ -254,8 +221,8 @@ TEST_F(GFAConstruction, NormalGraph)
 
   ASSERT_FALSE(gfa_parse.second->uses_translation()) << "Unnecessary segment translation";
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_no_translation(graph);
 }
 
@@ -278,8 +245,8 @@ TEST_F(GFAConstruction, WithZeroSegment)
   };
   this->check_translation(*(gfa_parse.second), translation);
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_translation(graph, translation);
 
   std::vector<edge_t> links =
@@ -316,8 +283,8 @@ TEST_F(GFAConstruction, StringSegmentNames)
   };
   this->check_translation(*(gfa_parse.second), translation);
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_translation(graph, translation);
 
   std::vector<edge_t> links =
@@ -355,8 +322,8 @@ TEST_F(GFAConstruction, SegmentChopping)
   };
   this->check_translation(*(gfa_parse.second), translation);
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_translation(graph, translation);
 
   std::vector<edge_t> links =
@@ -412,8 +379,8 @@ TEST_F(GFAConstructionReversal, ChoppingWithReversal)
   };
   this->check_translation(*(gfa_parse.second), translation);
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_translation(graph, translation);
 
   std::vector<edge_t> links =
@@ -434,8 +401,8 @@ TEST_F(GFAConstructionReversal, WalksWithReversal)
 
   ASSERT_FALSE(gfa_parse.second->uses_translation()) << "Unnecessary segment translation";
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_paths(graph, &(this->graph));
   this->check_no_translation(graph);
 }
@@ -459,8 +426,8 @@ TEST_F(GFAConstructionWalks, WalksAndPaths)
 
   ASSERT_FALSE(gfa_parse.second->uses_translation()) << "Unnecessary segment translation";
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_paths(graph, &(this->graph));
   this->check_no_translation(graph);
 }
@@ -473,8 +440,8 @@ TEST_F(GFAConstructionWalks, WalksOnly)
 
   ASSERT_FALSE(gfa_parse.second->uses_translation()) << "Unnecessary segment translation";
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_paths(graph, &(this->graph));
   this->check_no_translation(graph);
 }
@@ -501,8 +468,8 @@ TEST_F(GFAConstructionReference, ReferencePaths)
 
   ASSERT_FALSE(gfa_parse.second->uses_translation()) << "Unnecessary segment translation";
 
-  this->check_gbwt(index, &(this->index));
-  this->check_graph(graph, &(this->graph));
+  compare_gbwts(index, this->index, false, "");
+  compare_graphs(graph, this->graph, false, "");
   this->check_paths(graph, &(this->graph));
   this->check_no_translation(graph);
 }


### PR DESCRIPTION
`chunk_graph()` for chunking a GBZ graph into weakly connected components and a merge constructor for merging them back together. It is also possible to provide a contig name to `chunk_graph()` to only extract components containing a path with that contig name. Merging only works when the subgraphs are disjoint.

Chunking and merging are the inverse of each other, as long as the order of paths in the original full graph is consistent with the order of minimum node ids in the weakly connected components. The operations preserve reference samples and most graph name / relationship information. Merging loses all relationship information the chunks had. Node-to-segment translation is preserved in chunking but not in merging.

Subgraph constructors for `GBWTGraph` and `GBZ` now preserve reference samples, if they exist in the subgraph.