### PR TITLE
Expose constants for recombination-aware minimizer indexing

### DIFF
--- a/include/gbwtgraph/index.h
+++ b/include/gbwtgraph/index.h
@@ -44,17 +44,21 @@ void index_haplotypes
 // index_haplotypes_with_paths().
 extern const std::string PATH_NAME_FIELDS_TAG; // "path_name_fields"
 
+// Maximum number of samples where index_haplotypes_with_paths can still assign
+// distinct path IDs.
+extern const size_t MAX_PATH_IDS;
+
 /*
   Index the haplotypes in the graph. This version requires that
   index.payload_size() > 0. It gets the first index.payload_size() - 1 words of
   payload from the get_payload function and uses the last word to store the
   the set of haplotypes containing the minimizer hit.
 
-  This uses PathIDMap to map path names to integers in [0, 64). Depending on
+  This uses PathIdMap to map path names to integers in [0, 64). Depending on
   the GBWT metadata, the mapping may be based on (sample, contig, haplotype),
-  (sample, haplotype), or (sample). If there are too many samples, all paths
-  map to 0. The fields used in the mapping are stored in the minimizer index
-  tag PATH_NAME_FIELDS_TAG.
+  (sample, haplotype), or (sample). If there are too many samples (more than
+  MAX_PATH_IDS), all paths map to 0. The fields used in the mapping are stored
+  in the minimizer index tag PATH_NAME_FIELDS_TAG.
 
   The number of threads can be set through OpenMP. If the graph contains
   GraphName information, it will be copied to the minimizer index.

--- a/include/gbwtgraph/internal.h
+++ b/include/gbwtgraph/internal.h
@@ -349,6 +349,12 @@ struct PathIdMap
 
   enum class KeyType { NONE, SAMPLE, SAMPLE_HAPLOTYPE, SAMPLE_CONTIG_HAPLOTYPE };
 
+  // Build a PathIdMap from GBWT metatata. Assigns IDs to each distinguishable
+  // combination of path name fields. If there are too many haplotypes we would
+  // want to distinguish, produces an empty map.
+  //
+  // As long as there are MAX_HAPLOTYPES or fewer samples, the map will not be
+  // empty.
   explicit PathIdMap(const gbwt::Metadata& metadata);
 
   // Returns the number of distinct haplotypes in the map.

--- a/include/gbwtgraph/utils.h
+++ b/include/gbwtgraph/utils.h
@@ -138,6 +138,9 @@ extern const std::string REFERENCE_SAMPLE_LIST_GFA_TAG;
 // What separator character is used in lists of reference sample names?
 extern const char REFERENCE_SAMPLE_LIST_SEPARATOR;
 
+// What sample name prefix is used for generated path cover paths that do not represent observed haplotypes?
+extern const std::string COVER_PATH_SAMPLE_PREFIX;
+
 // Cached information for a named path.
 struct NamedPath
 {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -12,6 +12,9 @@ namespace gbwtgraph
 //------------------------------------------------------------------------------
 
 const std::string PATH_NAME_FIELDS_TAG = "path_name_fields";
+// We need this because PathIdMap is not meant to be part of the library
+// interface.
+const size_t MAX_PATH_IDS = PathIdMap::MAX_HAPLOTYPES;
 
 //------------------------------------------------------------------------------
 

--- a/src/path_cover.cpp
+++ b/src/path_cover.cpp
@@ -604,7 +604,7 @@ path_cover_gbwt(
     if(job >= paths_to_include.size()) { continue; }
     for(size_t i = 0; i < parameters.num_paths; i++)
     {
-      metadata.add_haplotype("path_cover_" + std::to_string(i), contig_names[component], 0, 0, job);
+      metadata.add_haplotype(COVER_PATH_SAMPLE_PREFIX + std::to_string(i), contig_names[component], 0, 0, job);
     }
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -45,6 +45,8 @@ const std::string REFERENCE_SAMPLE_LIST_GFA_TAG = "RS";
 // Since spaces are allowed in GFA tags, we can use them as sample name separators.
 const char REFERENCE_SAMPLE_LIST_SEPARATOR = ' ';
 
+const std::string COVER_PATH_SAMPLE_PREFIX = "path_cover_";
+
 //------------------------------------------------------------------------------
 
 // Other class variables.

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -628,6 +628,8 @@ TEST_F(PathIdTest, PathIdMap)
   this->path_id_map_test(5, 1, 13, 1, PathIdMap::KeyType::SAMPLE_HAPLOTYPE); // Fall back to (sample, haplotype).
   this->path_id_map_test(32, 2, 2, 1, PathIdMap::KeyType::SAMPLE_HAPLOTYPE); // Should still use (sample, haplotype).
   this->path_id_map_test(13, 5, 1, 1, PathIdMap::KeyType::SAMPLE); // Fall back to (sample).
+  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES, 1, 1, 1, PathIdMap::KeyType::SAMPLE); // Largest case where we can still use (sample)
+  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES + 1, 1, 1, 1, PathIdMap::KeyType::NONE); // Smallest case where we can no longer use (sample)
   this->path_id_map_test(230, 2, 24, 3, PathIdMap::KeyType::NONE); // Large test case, where everything should map to 0.
 }
 

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -628,8 +628,8 @@ TEST_F(PathIdTest, PathIdMap)
   this->path_id_map_test(5, 1, 13, 1, PathIdMap::KeyType::SAMPLE_HAPLOTYPE); // Fall back to (sample, haplotype).
   this->path_id_map_test(32, 2, 2, 1, PathIdMap::KeyType::SAMPLE_HAPLOTYPE); // Should still use (sample, haplotype).
   this->path_id_map_test(13, 5, 1, 1, PathIdMap::KeyType::SAMPLE); // Fall back to (sample).
-  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES, 1, 1, 1, PathIdMap::KeyType::SAMPLE); // Largest case where we can still use (sample)
-  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES + 1, 1, 1, 1, PathIdMap::KeyType::NONE); // Smallest case where we can no longer use (sample)
+  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES, 2, 24, 1, PathIdMap::KeyType::SAMPLE); // Largest case where we can still use (sample)
+  this->path_id_map_test(PathIdMap::MAX_HAPLOTYPES + 1, 2, 24, 1, PathIdMap::KeyType::NONE); // Smallest case where we can no longer use (sample)
   this->path_id_map_test(230, 2, 24, 3, PathIdMap::KeyType::NONE); // Large test case, where everything should map to 0.
 }
 


### PR DESCRIPTION
This exposes the prefix for path cover paths as a constant (so we can detect them in vg and not try and index them for recombination-aware mapping).

It also exposes the maximum number of samples where we can guarantee actually using them in the minimizer index path flag payloads, and adds testing to make sure that that is true and comments to document it.

I'm going to use this in https://github.com/vgteam/vg/pull/4911